### PR TITLE
Update to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.12.1"
+bevy = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "bevy_editor_prototypes"
-version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 bevy = "0.14.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
 
-fn main() {
-    App::new().add_plugins(DefaultPlugins).run();
+fn main() -> AppExit {
+    App::new().add_plugins(DefaultPlugins).run()
 }


### PR DESCRIPTION
This updates the `main` branch to use Bevy 0.14, though it does not touch the other branches. As part of this change, I also added `publish = false` to `Cargo.toml` to prevent it from accidentally being published on <https://crates.io>.