### PR TITLE
Setup `mdbook` checks and GitHub pages

### DIFF
--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -1,0 +1,54 @@
+name: Build and publish book
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  # This can be any valid Cargo version requirement, but should start with a caret `^` to opt-in to
+  # SemVer-compatible changes. Please keep this in sync with `ci.yaml`.
+  MDBOOK_VERSION: ^0.4.40
+
+permissions:
+  # Required to checkout repository.
+  contents: read
+  # Both are required to deploy to GitHub pages.
+  pages: write
+  id-token: write
+
+# Only allow one deployment to run at a time.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and publish book
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install mdbook
+        run: cargo install mdbook --version ${{ env.MDBOOK_VERSION }}
+
+      - name: Build book
+        working-directory: design-book
+        run: mdbook build
+
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: design-book/book
+
+      - name: Deploy to GitHub pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,10 @@ jobs:
       - name: Install mdbook
         run: cargo install mdbook --version ${{ env.MDBOOK_VERSION }}
 
+      - name: Build book
+        working-directory: design-book
+        run: mdbook build
+
       - name: Test code samples
         working-directory: design-book
         run: mdbook test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,9 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings
+  # This can be any valid Cargo version requirement, but should start with a caret `^` to opt-in to
+  # SemVer-compatible changes.
+  MDBOOK_VERSION: ^0.4.40
 
 jobs:
   # Run tests.
@@ -104,3 +107,22 @@ jobs:
 
       - name: Check documentation
         run: cargo doc --locked --workspace --all-features --document-private-items --no-deps
+
+  # Check design book.
+  book:
+    name: Book
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install mdbook
+        run: cargo install mdbook --version ${{ env.MDBOOK_VERSION }}
+
+      - name: Test code samples
+        working-directory: design-book
+        run: mdbook test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ env:
   RUSTFLAGS: --deny warnings
   RUSTDOCFLAGS: --deny warnings
   # This can be any valid Cargo version requirement, but should start with a caret `^` to opt-in to
-  # SemVer-compatible changes.
+  # SemVer-compatible changes. Please keep this in sync with `book.yaml`.
   MDBOOK_VERSION: ^0.4.40
 
 jobs:


### PR DESCRIPTION
Closes #13 and closes #14.

This PR does two things:

1. Runs `mdbook build` and `mdbook test` on all commits, PRs, and anything else that triggers `cy.yaml`.
    - The latter, `mdbook test`, checks that all Rust code snippets compile! Neat!
2. Runs `mdbook build` and deploys the results to GitHub Pages whenever a new commit is pushed to `main`.