### PR TITLE
add lint config, matching bevy's

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,28 @@ members = ["crates/*"]
 [[bin]]
 name = "bevy_editor_standalone"
 path = "crates/bevy_editor/src/main.rs"
+
+[workspace.lints.clippy]
+doc_markdown = "warn"
+manual_let_else = "warn"
+match_same_arms = "warn"
+redundant_closure_for_method_calls = "warn"
+redundant_else = "warn"
+semicolon_if_nothing_returned = "warn"
+type_complexity = "allow"
+undocumented_unsafe_blocks = "warn"
+unwrap_or_default = "warn"
+
+ptr_as_ptr = "warn"
+ptr_cast_constness = "warn"
+ref_as_ptr = "warn"
+
+[workspace.lints.rust]
+missing_docs = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(docsrs_dep)'] }
+unsafe_code = "deny"
+unsafe_op_in_unsafe_fn = "warn"
+unused_qualifications = "warn"
+
+[lints]
+workspace = true

--- a/crates/bevy_color_picker/Cargo.toml
+++ b/crates/bevy_color_picker/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_color_picker/src/lib.rs
+++ b/crates/bevy_color_picker/src/lib.rs
@@ -1,5 +1,6 @@
 //! A color picker widget for Bevy applications.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_command_palette/Cargo.toml
+++ b/crates/bevy_command_palette/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_command_palette/src/lib.rs
+++ b/crates/bevy_command_palette/src/lib.rs
@@ -5,6 +5,7 @@
 //!
 //! Search and keyboard shortcuts will both be supported.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_context_menu/Cargo.toml
+++ b/crates/bevy_context_menu/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_context_menu/src/lib.rs
+++ b/crates/bevy_context_menu/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate opens up a menu with a list of options when the user right-clicks (or otherwise triggers the context menu),
 //! based on what the user has clicked on.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_editor/Cargo.toml
+++ b/crates/bevy_editor/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_editor_camera/Cargo.toml
+++ b/crates/bevy_editor_camera/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_editor_camera/src/lib.rs
+++ b/crates/bevy_editor_camera/src/lib.rs
@@ -1,5 +1,6 @@
 //! A set of camera controllers suitable for controlling editor-style views and scene exploration.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_inspector/Cargo.toml
+++ b/crates/bevy_inspector/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_inspector/src/lib.rs
+++ b/crates/bevy_inspector/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! Data can be viewed and modified in real-time, with changes being reflected in the application.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_localization/Cargo.toml
+++ b/crates/bevy_localization/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_localization/src/lib.rs
+++ b/crates/bevy_localization/src/lib.rs
@@ -1,5 +1,6 @@
 //! A localization framework for Bevy applications, backed by Fluent.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_menu_bar/Cargo.toml
+++ b/crates/bevy_menu_bar/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_menu_bar/src/lib.rs
+++ b/crates/bevy_menu_bar/src/lib.rs
@@ -3,6 +3,7 @@
 //! This runs along the top of the screen and provides a list of options to the user,
 //! such as "File", "Edit", "View", etc.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_panes/Cargo.toml
+++ b/crates/bevy_panes/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_panes/src/lib.rs
+++ b/crates/bevy_panes/src/lib.rs
@@ -1,5 +1,6 @@
 //! Resizable, draggable, collapsible and dockable panes for Bevy.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_preferences/Cargo.toml
+++ b/crates/bevy_preferences/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_preferences/src/lib.rs
+++ b/crates/bevy_preferences/src/lib.rs
@@ -1,5 +1,6 @@
 //! A straightforward way to store and retrieve user preferences on disk for Bevy applications.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_scene_tree/Cargo.toml
+++ b/crates/bevy_scene_tree/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_scene_tree/src/lib.rs
+++ b/crates/bevy_scene_tree/src/lib.rs
@@ -1,5 +1,6 @@
 //! An interactive, collapsible tree view for hierarchical ECS data in Bevy.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_toolbar/Cargo.toml
+++ b/crates/bevy_toolbar/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_toolbar/src/lib.rs
+++ b/crates/bevy_toolbar/src/lib.rs
@@ -3,6 +3,7 @@
 //! Toolbars are a common UI element in many applications, providing quick access to frequently used commands,
 //! and typically display small icons with on-hover tooltips.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_tooltips/Cargo.toml
+++ b/crates/bevy_tooltips/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_tooltips/src/lib.rs
+++ b/crates/bevy_tooltips/src/lib.rs
@@ -1,5 +1,6 @@
 //! A tooltip system for Bevy applications, providing contextual information on hover.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_undo/Cargo.toml
+++ b/crates/bevy_undo/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_undo/src/lib.rs
+++ b/crates/bevy_undo/src/lib.rs
@@ -1,5 +1,6 @@
 //! An action-based undo-redo system for Bevy ECS data.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }

--- a/crates/bevy_widgets/Cargo.toml
+++ b/crates/bevy_widgets/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/bevy_widgets/src/lib.rs
+++ b/crates/bevy_widgets/src/lib.rs
@@ -1,5 +1,6 @@
 //! A collection of basic UI widgets for Bevy applications.
 
+/// an add function that adds two numbers
 pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }


### PR DESCRIPTION
* adds the lint config [from bevy's Cargo.tomls](https://github.com/bevyengine/bevy/blob/58f6fa94a2251665819ec8747287fab1ef151086/Cargo.toml#L33) including for sub-crates.
* adds a doc comment for each scaffolded add function, which is expected to be changed when a new crate is actually worked on.

closes #21 