### PR TITLE
Add bevy_asset_preview and bevy_marketplace_viewer crates

### DIFF
--- a/crates/bevy_asset_preview/Cargo.toml
+++ b/crates/bevy_asset_preview/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bevy_asset_preview"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bevy.workspace = true

--- a/crates/bevy_asset_preview/src/lib.rs
+++ b/crates/bevy_asset_preview/src/lib.rs
@@ -1,0 +1,14 @@
+use bevy::prelude::*;
+
+/// This crate is a work in progress and is not yet ready for use.
+/// The intention is to provide a way to load/render/unload assets in the background and provide previews of them in the Bevy Editor.
+/// For 2d assets this will be a simple sprite, for 3d assets this will require a quick render of the asset at a low resolution, just enough for a user to be able to tell quickly what it is.
+/// This code may be reused for the Bevy Marketplace Viewer to provide previews of assets and plugins.
+/// So long as the assets are unchanged, the previews will be cached and will not need to be re-rendered.
+/// In theory this can be done passively in the background, and the previews will be ready when the user needs them.
+
+pub struct AssetPreviewPlugin;
+#[allow(unused_variables)]
+impl Plugin for AssetPreviewPlugin {
+    fn build(&self, _app: &mut App) {}
+}

--- a/crates/bevy_marketplace_viewer/Cargo.toml
+++ b/crates/bevy_marketplace_viewer/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "bevy_marketplace_viewer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bevy.workspace = true

--- a/crates/bevy_marketplace_viewer/src/lib.rs
+++ b/crates/bevy_marketplace_viewer/src/lib.rs
@@ -1,0 +1,16 @@
+use bevy::prelude::*;
+
+/// A Viewer for the Future Bevy Marketplace, a place where you can find Bevy plugins and assets that members of the community have created.
+/// This crate is a work in progress and is not yet ready for use.
+/// The intention is to provide a way to browse the marketplace and install plugins and assets directly from the Bevy Editor.
+/// Particularly, this crate will connect to the Bevy Marketplace API to fetch the latest plugins and assets, and provide previews, overviews, and (If any) prices of them.
+/// If the crate is present in the editor (aka not been removed, or disabled).
+/// The crate will pass this data to the asset browser crate to be displayed in the Bevy Editor.
+/// The UI/UX of the content will live in the asset browser crate, and this crate will only be responsible for fetching the data.
+/// As a security measure purchasing of assets/plugins will be done through the Bevy Marketplace website.
+
+pub struct MarketplaceViewerPlugin;
+#[allow(unused_variables)]
+impl Plugin for MarketplaceViewerPlugin {
+    fn build(&self, _app: &mut App) {}
+}


### PR DESCRIPTION
(Redo of previous PR)
Adds bevy_marketplace_viewer crate built in to be ready to begin implementing the marketplace when the website is ready for it.
To be clear, this will just be for handling the connection between the editor and bevy foundation and (maybe?) additional visuals that the asset browser won't have (like a price tag widget, etc). This is a separate crate from the asset browser for ease of removal if a user wishes, ideally this is a top level crate that nothing else depends on.

Also adds a bevy_asset_preview crate, I imagine this to be a background process quietly scanning the asset folder and generating appropriate previews for assets not generally easy to display, this adds parity with the previews the marketplace will most likely have as well as making asset browsing easier and faster. 