### PR TITLE
Add Docs covering layout system, Rename bevy_panes to bevy_pane_layout

### DIFF
--- a/crates/bevy_pane_layout/Cargo.toml
+++ b/crates/bevy_pane_layout/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bevy_panes"
+name = "bevy_pane_layout"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/bevy_pane_layout/src/lib.rs
+++ b/crates/bevy_pane_layout/src/lib.rs
@@ -1,4 +1,17 @@
-//! Resizable, draggable, collapsible and dockable panes for Bevy.
+//! Resizable, split-able panes for Bevy.
+/// The Bevy Pane Layout system.
+/// The intent of this system is to provide a way to create resizable, split-able panes in Bevy.
+/// Mimicking the behavior of of Blender's layout system.
+///
+/// Blender Documentation: <https://docs.blender.org/manual/en/latest/interface/window_system/areas.html>
+///
+/// Requirements for a valid Pane:
+/// - All panes must fit within their bounds, no overflow is allowed.
+/// - Panes can not have power over the layout system, their dimensions are controlled by the layout system and should not be modified by anything else.
+/// - All panes must have a header, a content area, however a footer is optional.
+/// - Panes cannot have min/max sizes, they must be able to be resized to any size.
+///   - If a pane can not be sensibly resized, it can overflow under the other panes.
+/// - Panes must not interfere with each other, only temporary/absolute positioned elements are allowed to overlap panes.
 use bevy::prelude::*;
 
 /// Basic add function, will be removed later.


### PR DESCRIPTION
Added documentation about the layout system and a reference to the blender docs, renamed the crate to better emphasize that this will only contain the layout system once BSN is available to us.