### PR TITLE
Added an idea for launch targets/profiles

### DIFF
--- a/design-book/src/roadmap.md
+++ b/design-book/src/roadmap.md
@@ -108,6 +108,12 @@ It's best not to plan too far in advance!
   - [ ] blank
   - [ ] from template
 - [ ] localization framework (first-party: English-only)
+- [ ] launch targets/profiles
+  - [ ] launch a prebuilt binary (for non-technical users)
+  - [ ] cargo workspace apps and examples (for developers using the editor from the codebase)
+    - [ ] set feature flags
+    - [ ] (stretch goal. maybe as part of a possible vscode integration) read/write `.vscode/launch.json`
+  - [ ] option to launch with a default profile when the editor opens
 
 ## Uncategorized work
 


### PR DESCRIPTION
Hey, as per @alice-i-cecile 's suggestion I'm submitting my suggestion here.

From the current docs and some mocks from the discord I haven't really seen multi-target support mentioned. I have a repo with multiple small applications and examples and it would be really nice for the editor to be able to define launch targets for them including feature flags. Kinda like how you have multiple debug targets in vscode or intelliJ.