### PR TITLE
Update write permissions of bevy update job

### DIFF
--- a/.github/workflows/update-bevy.yaml
+++ b/.github/workflows/update-bevy.yaml
@@ -8,6 +8,10 @@ on:
 jobs:
   update-bevy:
     runs-on: ubuntu-latest
+      
+    permissions:
+      # Allows pushing to the repository
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Should hopefully fix the [failed job](https://github.com/bevyengine/bevy_editor_prototypes/actions/runs/11097148373).

I'm not 100% sure if we additionally have to ensure that GitHub Actions has the right level of access to the repository. (I currently don't have access to the repo settings)