### PR TITLE
Add Context Menu Widget

### DIFF
--- a/bevy_widgets/bevy_context_menu/Cargo.toml
+++ b/bevy_widgets/bevy_context_menu/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bevy.workspace = true
+bevy_editor_styles.workspace = true
 
 [lints]
 workspace = true

--- a/bevy_widgets/bevy_context_menu/examples/simple.rs
+++ b/bevy_widgets/bevy_context_menu/examples/simple.rs
@@ -1,0 +1,36 @@
+//! Simple context menu example.
+
+use bevy::prelude::*;
+use bevy_context_menu::{ContextMenu, ContextMenuOption, ContextMenuPlugin};
+use bevy_editor_styles::StylesPlugin;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, StylesPlugin, ContextMenuPlugin))
+        .add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Camera2d);
+            commands.spawn((
+                NodeBundle {
+                    style: Style {
+                        width: Val::Percent(100.),
+                        height: Val::Percent(100.),
+                        ..default()
+                    },
+                    ..default()
+                },
+                ContextMenu::new(vec![
+                    ContextMenuOption::new("Turn Red", |mut commands, entity| {
+                        commands
+                            .entity(entity)
+                            .insert(BackgroundColor(Color::srgb(0.2, 0., 0.)));
+                    }),
+                    ContextMenuOption::new("Turn Blue", |mut commands, entity| {
+                        commands
+                            .entity(entity)
+                            .insert(BackgroundColor(Color::srgb(0., 0., 0.2)));
+                    }),
+                ]),
+            ));
+        })
+        .run();
+}

--- a/bevy_widgets/bevy_context_menu/examples/simple.rs
+++ b/bevy_widgets/bevy_context_menu/examples/simple.rs
@@ -9,13 +9,12 @@ fn main() {
         .add_plugins((DefaultPlugins, StylesPlugin, ContextMenuPlugin))
         .add_systems(Startup, |mut commands: Commands| {
             commands.spawn(Camera2d);
+
             commands.spawn((
-                NodeBundle {
-                    style: Style {
-                        width: Val::Percent(100.),
-                        height: Val::Percent(100.),
-                        ..default()
-                    },
+                Node::default(),
+                Style {
+                    width: Val::Percent(100.),
+                    height: Val::Percent(100.),
                     ..default()
                 },
                 ContextMenu::new(vec![

--- a/bevy_widgets/bevy_context_menu/src/lib.rs
+++ b/bevy_widgets/bevy_context_menu/src/lib.rs
@@ -34,14 +34,14 @@ fn on_secondary_button_down_entity_with_context_menu(
 
     // Prevent all other entities from being picked by placing a node over the entire window.
     let root = commands
-        .spawn(NodeBundle {
-            style: Style {
+        .spawn((
+            Node::default(),
+            Style {
                 width: Val::Percent(100.),
                 height: Val::Percent(100.),
                 ..default()
             },
-            ..default()
-        })
+        ))
         .observe(|trigger: Trigger<Pointer<Down>>, mut commands: Commands| {
             commands.entity(trigger.entity()).despawn_recursive();
         })

--- a/bevy_widgets/bevy_context_menu/src/lib.rs
+++ b/bevy_widgets/bevy_context_menu/src/lib.rs
@@ -1,20 +1,97 @@
-//! A context menu abstraction for Bevy applications.
-//!
-//! This crate opens up a menu with a list of options when the user right-clicks (or otherwise triggers the context menu),
-//! based on what the user has clicked on.
+//! A context menu for the Bevy Editor
 
-/// an add function that adds two numbers
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+mod ui;
+
+use std::sync::{Arc, Mutex};
+
+use bevy::prelude::*;
+use bevy_editor_styles::Theme;
+
+use crate::ui::spawn_context_menu;
+
+/// A context menu for the Bevy Editor
+pub struct ContextMenuPlugin;
+
+impl Plugin for ContextMenuPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_observer(on_secondary_button_down_entity_with_context_menu);
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+fn on_secondary_button_down_entity_with_context_menu(
+    trigger: Trigger<Pointer<Down>>,
+    mut commands: Commands,
+    query: Query<&ContextMenu>,
+    theme: Res<Theme>,
+) {
+    let event = trigger.event();
+    if event.button != PointerButton::Secondary {
+        return;
+    }
+    let target = trigger.entity();
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    let Ok(menu) = query.get(target) else {
+        return;
+    };
+
+    // Prevent all other entities from being picked by placing a node over the entire window.
+    let root = commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.),
+                height: Val::Percent(100.),
+                ..default()
+            },
+            ..default()
+        })
+        .observe(|trigger: Trigger<Pointer<Down>>, mut commands: Commands| {
+            commands.entity(trigger.entity()).despawn_recursive();
+        })
+        .id();
+
+    spawn_context_menu(
+        &mut commands,
+        &theme,
+        menu,
+        event.pointer_location.position,
+        target,
+    )
+    .observe(|mut trigger: Trigger<Pointer<Down>>| {
+        // Prevent the context menu root from despawning the context menu when clicking on the menu
+        trigger.propagate(false);
+    })
+    .set_parent(root);
+}
+
+/// Entities with this component will
+#[derive(Component)]
+pub struct ContextMenu {
+    options: Vec<ContextMenuOption>,
+}
+
+impl ContextMenu {
+    /// Create a new [`ContextMenu`] from a list of [`ContextMenuOption`]s.
+    pub fn new(options: impl IntoIterator<Item = ContextMenuOption>) -> Self {
+        let options = options.into_iter().collect();
+        ContextMenu { options }
+    }
+}
+
+/// An option inside a [`ContextMenu`].
+pub struct ContextMenuOption {
+    label: String,
+    f: Arc<Mutex<dyn FnMut(Commands, Entity) + Send + Sync>>,
+}
+
+impl ContextMenuOption {
+    /// Create a new [`ContextMenuOption`].
+    pub fn new(
+        label: impl Into<String>,
+        f: impl FnMut(Commands, Entity) + Send + Sync + 'static,
+    ) -> Self {
+        ContextMenuOption {
+            label: label.into(),
+            f: Arc::new(Mutex::new(f)),
+        }
     }
 }

--- a/bevy_widgets/bevy_context_menu/src/lib.rs
+++ b/bevy_widgets/bevy_context_menu/src/lib.rs
@@ -2,8 +2,6 @@
 
 mod ui;
 
-use std::sync::{Arc, Mutex};
-
 use bevy::prelude::*;
 use bevy_editor_styles::Theme;
 
@@ -80,7 +78,7 @@ impl ContextMenu {
 /// An option inside a [`ContextMenu`].
 pub struct ContextMenuOption {
     label: String,
-    f: Arc<Mutex<dyn FnMut(Commands, Entity) + Send + Sync>>,
+    f: Box<dyn FnMut(Commands, Entity) + Send + Sync>,
 }
 
 impl ContextMenuOption {
@@ -91,7 +89,7 @@ impl ContextMenuOption {
     ) -> Self {
         ContextMenuOption {
             label: label.into(),
-            f: Arc::new(Mutex::new(f)),
+            f: Box::new(f),
         }
     }
 }

--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -1,0 +1,114 @@
+use bevy::{prelude::*, window::SystemCursorIcon, winit::cursor::CursorIcon};
+use bevy_editor_styles::Theme;
+
+use crate::{ContextMenu, ContextMenuOption};
+
+pub(crate) fn spawn_context_menu<'a>(
+    commands: &'a mut Commands,
+    theme: &Theme,
+    menu: &ContextMenu,
+    position: Vec2,
+    target: Entity,
+) -> EntityCommands<'a> {
+    let root = commands
+        .spawn(NodeBundle {
+            background_color: theme.context_menu_background_color,
+            border_radius: theme.border_radius,
+            style: Style {
+                position_type: PositionType::Absolute,
+                top: Val::Px(position.y),
+                left: Val::Px(position.x),
+                flex_direction: FlexDirection::Column,
+                padding: UiRect::all(Val::Px(3.)),
+                width: Val::Px(300.),
+                ..default()
+            },
+            ..default()
+        })
+        .id();
+
+    for option in &menu.options {
+        spawn_option(commands, theme, option, target).set_parent(root);
+    }
+
+    commands.entity(root)
+}
+
+pub(crate) fn spawn_option<'a>(
+    commands: &'a mut Commands,
+    theme: &Theme,
+    option: &ContextMenuOption,
+    target: Entity,
+) -> EntityCommands<'a> {
+    let callback = option.f.clone();
+    let root = commands
+        .spawn(NodeBundle {
+            border_radius: theme.button_border_radius,
+            style: Style {
+                padding: UiRect::all(Val::Px(5.)),
+                flex_grow: 1.,
+                ..default()
+            },
+            ..default()
+        })
+        .observe(
+            |trigger: Trigger<Pointer<Over>>,
+             theme: Res<Theme>,
+             mut query: Query<&mut BackgroundColor>| {
+                *query.get_mut(trigger.entity()).unwrap() =
+                    theme.context_menu_button_hover_background_color;
+            },
+        )
+        .observe(
+            |trigger: Trigger<Pointer<Out>>, mut query: Query<&mut BackgroundColor>| {
+                query.get_mut(trigger.entity()).unwrap().0 = Color::NONE;
+            },
+        )
+        .observe(
+            move |_trigger: Trigger<Pointer<Over>>,
+                  window_query: Query<Entity, With<Window>>,
+                  mut commands: Commands| {
+                let window = window_query.single();
+                commands
+                    .entity(window)
+                    .insert(CursorIcon::System(SystemCursorIcon::Pointer));
+            },
+        )
+        .observe(
+            |_trigger: Trigger<Pointer<Out>>,
+             window_query: Query<Entity, With<Window>>,
+             mut commands: Commands| {
+                let window = window_query.single();
+                commands
+                    .entity(window)
+                    .insert(CursorIcon::System(SystemCursorIcon::Default));
+            },
+        )
+        .observe(
+            move |trigger: Trigger<Pointer<Up>>,
+                  mut commands: Commands,
+                  parent_query: Query<&Parent>| {
+                // Despawn context menu
+                let root = parent_query
+                    .iter_ancestors(trigger.entity())
+                    .last()
+                    .unwrap();
+                commands.entity(root).despawn_recursive();
+                callback.lock().unwrap()(commands.reborrow(), target);
+            },
+        )
+        .id();
+
+    commands
+        .spawn((
+            Text::new(&option.label),
+            TextFont {
+                font_size: 12.,
+                ..default()
+            },
+            PickingBehavior::IGNORE,
+        ))
+        .set_parent(root);
+
+    commands.entity(root)
+}

--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -11,10 +11,11 @@ pub(crate) fn spawn_context_menu<'a>(
     target: Entity,
 ) -> EntityCommands<'a> {
     let root = commands
-        .spawn(NodeBundle {
-            background_color: theme.context_menu_background_color,
-            border_radius: theme.border_radius,
-            style: Style {
+        .spawn((
+            Node::default(),
+            theme.context_menu_background_color,
+            theme.border_radius,
+            Style {
                 position_type: PositionType::Absolute,
                 top: Val::Px(position.y),
                 left: Val::Px(position.x),
@@ -23,8 +24,7 @@ pub(crate) fn spawn_context_menu<'a>(
                 width: Val::Px(300.),
                 ..default()
             },
-            ..default()
-        })
+        ))
         .id();
 
     for (i, option) in menu.options.iter().enumerate() {
@@ -42,15 +42,15 @@ pub(crate) fn spawn_option<'a>(
     target: Entity,
 ) -> EntityCommands<'a> {
     let root = commands
-        .spawn(NodeBundle {
-            border_radius: theme.button_border_radius,
-            style: Style {
+        .spawn((
+            Node::default(),
+            theme.button_border_radius,
+            Style {
                 padding: UiRect::all(Val::Px(5.)),
                 flex_grow: 1.,
                 ..default()
             },
-            ..default()
-        })
+        ))
         .observe(
             |trigger: Trigger<Pointer<Over>>,
              theme: Res<Theme>,

--- a/crates/bevy_editor_styles/src/lib.rs
+++ b/crates/bevy_editor_styles/src/lib.rs
@@ -29,6 +29,13 @@ pub struct Theme {
     pub border_radius: BorderRadius,
     /// Pane header Border Radius
     pub pane_header_border_radius: BorderRadius,
+    /// The default button Border Radius.
+    pub button_border_radius: BorderRadius,
+
+    /// The background color of the context menu.
+    pub context_menu_background_color: BackgroundColor,
+    /// The background color of the context menu options when hovered.
+    pub context_menu_button_hover_background_color: BackgroundColor,
 }
 
 impl Default for Theme {
@@ -41,6 +48,10 @@ impl Default for Theme {
             menu_bar_color: BackgroundColor(Color::oklch(0.209, 0.0, 0.0)),
             border_radius: BorderRadius::all(Val::Px(6.)),
             pane_header_border_radius: BorderRadius::top(Val::Px(6.)),
+
+            context_menu_background_color: Color::oklch(0.2, 0., 0.).into(),
+            context_menu_button_hover_background_color: Color::oklch(0.27, 0., 0.).into(),
+            button_border_radius: BorderRadius::all(Val::Px(4.)),
         }
     }
 }


### PR DESCRIPTION
### Testing
`cargo run -p bevy_context_menu --example simple`

### Showcase
![image](https://github.com/user-attachments/assets/a1b1d113-737c-4f60-ab45-fbaeac60731f)

### Future Work
- Prevent the menu from getting clipped at the edge of the window