### PR TITLE
Scroll box widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ bevy_command_palette = { path = "bevy_widgets/bevy_command_palette" }
 bevy_context_menu = { path = "bevy_widgets/bevy_context_menu" }
 bevy_i-cant-believe-its-not-bsn = { path = "bevy_widgets/bevy_i-cant-believe-its-not-bsn" }
 bevy_menu_bar = { path = "bevy_widgets/bevy_menu_bar" }
+bevy_scroll_box = { path = "bevy_widgets/bevy_scroll_box" }
 bevy_footer_bar = { path = "bevy_widgets/bevy_footer_bar" }
 bevy_toolbar = { path = "bevy_widgets/bevy_toolbar" }
 bevy_tooltips = { path = "bevy_widgets/bevy_tooltips" }

--- a/bevy_editor_panes/bevy_asset_browser/Cargo.toml
+++ b/bevy_editor_panes/bevy_asset_browser/Cargo.toml
@@ -10,6 +10,7 @@ bevy.workspace = true
 bevy_asset = "0.14.2"
 bevy_editor_styles.workspace = true
 bevy_pane_layout.workspace = true
+bevy_scroll_box.workspace = true
 atomicow.workspace = true
 
 [lints]

--- a/bevy_editor_panes/bevy_asset_browser/src/directory_content.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/directory_content.rs
@@ -1,6 +1,5 @@
 use bevy::{
     asset::io::AssetSourceBuilders,
-    input::mouse::{MouseScrollUnit, MouseWheel},
     prelude::*,
     tasks::{
         block_on,
@@ -11,11 +10,13 @@ use bevy::{
     winit::cursor::CursorIcon,
 };
 use bevy_editor_styles::Theme;
+use bevy_scroll_box::ScrollBox;
 
 use crate::{AssetBrowserLocation, AssetType};
 
 /// The root node for the directory content view
 #[derive(Component)]
+#[require(Node)]
 pub struct DirectoryContentNode;
 
 /// One entry of [`DirectoryContent`]
@@ -104,37 +105,6 @@ pub fn fetch_directory_content(
         .insert(FetchDirectoryContentTask(task));
 }
 
-#[derive(Component, Default)]
-pub(crate) struct ScrollingList {
-    position: f32,
-}
-
-// TODO: Replace with an editor widget
-/// Handle the scrolling of the content list
-pub(crate) fn scrolling(
-    mut mouse_wheel_events: EventReader<MouseWheel>,
-    mut query_list: Query<(&mut ScrollingList, &ComputedNode, &Parent, &mut Node)>,
-    query_node: Query<&ComputedNode>,
-) {
-    for mouse_wheel_event in mouse_wheel_events.read() {
-        for (mut scrolling_list, list_computed_node, parent, mut list_node) in &mut query_list {
-            let items_height = list_computed_node.size().y;
-            let container_height = query_node.get(parent.get()).unwrap().size().y;
-            let max_scroll = (items_height - container_height).max(0.);
-
-            let dy = match mouse_wheel_event.unit {
-                MouseScrollUnit::Line => mouse_wheel_event.y * 20.0,
-                MouseScrollUnit::Pixel => mouse_wheel_event.y,
-            };
-
-            scrolling_list.position += dy;
-            scrolling_list.position = scrolling_list.position.clamp(-max_scroll, 0.);
-
-            list_node.top = Val::Px(scrolling_list.position);
-        }
-    }
-}
-
 /// Check if the [`DirectoryContent`] has changed, which relate to the content of the current [`AssetBrowserLocation`]
 pub(crate) fn run_if_content_as_changed(directory_content: Res<DirectoryContent>) -> bool {
     directory_content.is_changed()
@@ -143,7 +113,7 @@ pub(crate) fn run_if_content_as_changed(directory_content: Res<DirectoryContent>
 /// Refresh the UI with the content of the current [`AssetBrowserLocation`]
 pub(crate) fn refresh_ui(
     mut commands: Commands,
-    content_list_query: Query<(Entity, Option<&Children>), With<ScrollingList>>,
+    content_list_query: Query<(Entity, Option<&Children>), With<ScrollBox>>,
     theme: Res<Theme>,
     asset_server: Res<AssetServer>,
     directory_content: Res<DirectoryContent>,

--- a/bevy_editor_panes/bevy_asset_browser/src/lib.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/lib.rs
@@ -5,10 +5,6 @@ use std::{path::PathBuf, time::SystemTime};
 
 use atomicow::CowArc;
 use bevy::{
-    a11y::{
-        accesskit::{NodeBuilder, Role},
-        AccessibilityNode,
-    },
     asset::{
         embedded_asset,
         io::{AssetSource, AssetSourceBuilders, AssetSourceId},
@@ -18,7 +14,8 @@ use bevy::{
 };
 use bevy_editor_styles::Theme;
 use bevy_pane_layout::{PaneContentNode, PaneRegistry};
-use directory_content::{DirectoryContentNode, ScrollingList};
+use bevy_scroll_box::{spawn_scroll_box, ScrollBoxPlugin};
+use directory_content::DirectoryContentNode;
 use top_bar::TopBarNode;
 
 mod directory_content;
@@ -39,13 +36,14 @@ impl Plugin for AssetBrowserPanePlugin {
                 commands.entity(pane_root).insert(AssetBrowserNode);
             });
 
-        app.insert_resource(AssetBrowserLocation::default())
+        app.add_plugins(ScrollBoxPlugin)
+            .insert_resource(AssetBrowserLocation::default())
             .insert_resource(directory_content::DirectoryContent::default())
             .init_resource::<AssetBrowserOneShotSystems>()
             .insert_resource(DirectoryLastModifiedTime(SystemTime::UNIX_EPOCH))
             .add_observer(on_pane_creation)
             .add_systems(Startup, directory_content::fetch_directory_content)
-            .add_systems(Update, (button_interaction, directory_content::scrolling))
+            .add_systems(Update, button_interaction)
             .add_systems(
                 Update,
                 (
@@ -152,26 +150,16 @@ pub fn on_pane_creation(
 
             // Directory content
             parent
-                .spawn(DirectoryContentNode)
-                .insert((Node {
-                    flex_direction: FlexDirection::Column,
-                    width: Val::Percent(100.0),
-                    height: Val::Percent(100.0),
-                    align_self: AlignSelf::Stretch,
-                    overflow: Overflow::clip_y(),
-                    ..default()
-                },))
+                .spawn((
+                    DirectoryContentNode,
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Percent(100.0),
+                        ..default()
+                    },
+                ))
                 .with_children(|parent| {
-                    // Scroll box moving panel
-                    parent.spawn((
-                        Node {
-                            position_type: PositionType::Absolute,
-                            flex_wrap: FlexWrap::Wrap,
-                            ..default()
-                        },
-                        ScrollingList::default(),
-                        AccessibilityNode(NodeBuilder::new(Role::Grid)),
-                    ));
+                    spawn_scroll_box(parent, &theme);
                 });
         });
 

--- a/bevy_widgets/bevy_scroll_box/Cargo.toml
+++ b/bevy_widgets/bevy_scroll_box/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bevy_scroll_box"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bevy.workspace = true
+bevy_editor_styles.workspace = true
+
+[lints]
+workspace = true
+

--- a/bevy_widgets/bevy_scroll_box/src/lib.rs
+++ b/bevy_widgets/bevy_scroll_box/src/lib.rs
@@ -1,0 +1,145 @@
+//! A scroll widget for Bevy applications.
+
+use bevy::{
+    a11y::{
+        accesskit::{NodeBuilder, Role},
+        AccessibilityNode,
+    },
+    input::mouse::{MouseScrollUnit, MouseWheel},
+    prelude::*,
+};
+use bevy_editor_styles::Theme;
+
+/// The plugin that handle all the scroll boxes.
+pub struct ScrollBoxPlugin;
+
+const SCROLL_LINE_SIZE_VALUE: f32 = 20.0;
+
+impl Plugin for ScrollBoxPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, on_scroll)
+            .add_systems(Update, update_scroll_bars);
+    }
+}
+
+/// The box that's scrollable. (The content of the scroll box)
+#[derive(Component, Default)]
+#[require(Node)]
+pub struct ScrollBox {
+    /// The position of the scroll box, relative to the it's container. (`position` < 0)
+    pub position: f32,
+}
+
+/// The scroll bar of the scroll box.
+#[derive(Component, Default)]
+#[require(Node)]
+pub struct ScrollBar;
+
+/// The handle of the scroll bar.
+#[derive(Component, Default)]
+#[require(Node)]
+pub struct ScrollBarHandle;
+
+/// Spawn and attach a scroll box to the parent.
+pub fn spawn_scroll_box<'a>(
+    parent: &'a mut ChildBuilder,
+    theme: &Res<Theme>,
+) -> EntityCommands<'a> {
+    let mut commands = parent.spawn(Node {
+        flex_direction: FlexDirection::RowReverse,
+        overflow: Overflow::clip_y(),
+        width: Val::Percent(100.0),
+        height: Val::Percent(100.0),
+        ..default()
+    });
+    commands.with_children(|parent| {
+        parent.spawn((
+            ScrollBox::default(),
+            AccessibilityNode(NodeBuilder::new(Role::List)),
+            Node {
+                position_type: PositionType::Absolute,
+                flex_wrap: FlexWrap::Wrap,
+                ..default()
+            },
+        ));
+        parent
+            .spawn((
+                ScrollBar,
+                Node {
+                    width: Val::Px(10.0),
+                    height: Val::Percent(100.0),
+                    ..default()
+                },
+                BackgroundColor(theme.scroll_bar_color),
+                BorderRadius::all(Val::Px(5.0)),
+            ))
+            .with_children(|parent| {
+                parent.spawn((
+                    ScrollBarHandle,
+                    Node {
+                        width: Val::Percent(100.0),
+                        height: Val::Percent(100.0),
+                        ..default()
+                    },
+                    BackgroundColor(theme.scroll_bar_handle_color),
+                    BorderRadius::all(Val::Px(5.0)),
+                ));
+            });
+    });
+    commands
+}
+
+fn on_scroll(
+    mut mouse_wheel_events: EventReader<MouseWheel>,
+    mut query_list: Query<(&mut ScrollBox, &mut Node, &Parent, &ComputedNode)>,
+    query_computed_node: Query<&ComputedNode>,
+) {
+    for mouse_wheel_event in mouse_wheel_events.read() {
+        for (mut scrolling_list, mut list_node, container, list_computed_node) in &mut query_list {
+            let list_height = list_computed_node.size().y;
+            let container_height = query_computed_node.get(container.get()).unwrap().size().y;
+            let max_scroll = (list_height - container_height).max(0.);
+            let delta_y = match mouse_wheel_event.unit {
+                MouseScrollUnit::Line => mouse_wheel_event.y * SCROLL_LINE_SIZE_VALUE,
+                MouseScrollUnit::Pixel => mouse_wheel_event.y,
+            };
+            scrolling_list.position += delta_y;
+            scrolling_list.position = scrolling_list.position.clamp(-max_scroll, 0.);
+            list_node.top = Val::Px(scrolling_list.position);
+        }
+    }
+}
+
+fn update_scroll_bars(
+    query_list: Query<(&ScrollBox, &Parent, &ComputedNode)>,
+    mut query_scroll_bar_style: ParamSet<(
+        Query<&mut Node, With<ScrollBar>>,
+        Query<&mut Node, With<ScrollBarHandle>>,
+    )>,
+    query_computed_node: Query<&ComputedNode>,
+) {
+    for (scrolling_list, container, list_computed_node) in query_list.iter() {
+        let list_height = list_computed_node.size().y;
+        let container_height = query_computed_node.get(container.get()).unwrap().size().y;
+        let handle_height = (container_height / list_height * 100.0).clamp(5.0, 100.0);
+        let handle_position = (-scrolling_list.position / list_height * 100.0).clamp(0.0, 100.0);
+
+        {
+            let mut bar_style_query = query_scroll_bar_style.p0();
+            let mut bar_node = bar_style_query.single_mut();
+            if handle_height == 100.0 {
+                bar_node.display = Display::None;
+                return;
+            }
+            bar_node.display = Display::DEFAULT;
+        }
+
+        {
+            let mut handle_node_query = query_scroll_bar_style.p1();
+            let mut handle_node = handle_node_query.single_mut();
+
+            handle_node.height = Val::Percent(handle_height);
+            handle_node.top = Val::Percent(handle_position);
+        }
+    }
+}

--- a/crates/bevy_editor_styles/src/lib.rs
+++ b/crates/bevy_editor_styles/src/lib.rs
@@ -44,6 +44,11 @@ pub struct Theme {
     pub low_priority_text_color: Color,
     /// The text color for high priority text. Text that the user needs to see asap.
     pub high_priority_text_color: Color,
+
+    /// The scroll bar color.
+    pub scroll_bar_color: Color,
+    /// The scroll bar handle color.
+    pub scroll_bar_handle_color: Color,
 }
 
 impl Default for Theme {
@@ -73,6 +78,10 @@ impl Default for Theme {
             low_priority_text_color: Color::oklch(0.50, 0.0, 0.0),
             text_color: Color::oklch(0.9219, 0.0, 0.0),
             high_priority_text_color: Color::oklch(0.209, 0.0, 0.0),
+
+            // Scroll bar styles
+            scroll_bar_color: Color::oklch(0.4, 0.0, 0.0),
+            scroll_bar_handle_color: Color::oklch(0.325, 0.0, 0.0),
         }
     }
 }


### PR DESCRIPTION
⚠️ #78 need to be merged first

Adding a `ScrollBox` widget
![scroll_bar_demo](https://github.com/user-attachments/assets/47993995-6602-4007-b7d0-f010b0fa384d)
(also the bar disappear if there is no content clipped) 

At the moment, the `ScrollBar` is being recalculated every frame.
It's far from being efficient, but I don't know how to react to UI being resized
I recon we could refresh on scroll and windows resizing event, but there's still cases were it might break (e.g pane_layout resize)