### PR TITLE
Fix context menu not appearing + Add drop shadow

### DIFF
--- a/bevy_widgets/bevy_context_menu/src/lib.rs
+++ b/bevy_widgets/bevy_context_menu/src/lib.rs
@@ -34,11 +34,14 @@ fn on_secondary_button_down_entity_with_context_menu(
 
     // Prevent all other entities from being picked by placing a node over the entire window.
     let root = commands
-        .spawn(Node {
-            width: Val::Percent(100.),
-            height: Val::Percent(100.),
-            ..default()
-        })
+        .spawn((
+            Node {
+                width: Val::Percent(100.),
+                height: Val::Percent(100.),
+                ..default()
+            },
+            ZIndex(10),
+        ))
         .observe(|trigger: Trigger<Pointer<Down>>, mut commands: Commands| {
             commands.entity(trigger.entity()).despawn_recursive();
         })

--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -21,6 +21,13 @@ pub(crate) fn spawn_context_menu<'a>(
                 width: Val::Px(300.),
                 ..default()
             },
+            BoxShadow {
+                blur_radius: Val::Px(3.),
+                x_offset: Val::ZERO,
+                y_offset: Val::ZERO,
+                color: Color::BLACK.with_alpha(0.8),
+                ..Default::default()
+            },
             theme.context_menu_background_color,
             theme.border_radius,
         ))


### PR DESCRIPTION
- Turns out root nodes don't always follow the rule that nodes that are spawned later are drawn on top of earlier nodes. Added a `ZIndex` offset to ensure the context menu is above the other UI.
  Fixes #93
- Added a drop shadow to the context menu to help separate it from the background.

### Showcase
![image](https://github.com/user-attachments/assets/dde4e403-a077-4131-a9bf-65d576c2f584)
