### PR TITLE
Viewport node + Pane header fixes

### DIFF
--- a/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
@@ -135,11 +135,14 @@ fn on_pane_creation(
 }
 
 fn update_render_target_size(
-    query: Query<(Entity, &Bevy2dViewport), Changed<Node>>,
+    query: Query<(Entity, &Bevy2dViewport)>,
     mut camera_query: Query<(&Camera, &mut EditorCamera2d)>,
     content: Query<&PaneContentNode>,
     children_query: Query<&Children>,
-    pos_query: Query<(&ComputedNode, &GlobalTransform)>,
+    pos_query: Query<
+        (&ComputedNode, &GlobalTransform),
+        Or<(Changed<ComputedNode>, Changed<GlobalTransform>)>,
+    >,
     mut images: ResMut<Assets<Image>>,
 ) {
     for (pane_root, viewport) in &query {
@@ -148,8 +151,10 @@ fn update_render_target_size(
             .find(|e| content.contains(*e))
             .unwrap();
 
+        let Ok((computed_node, global_transform)) = pos_query.get(content_node_id) else {
+            continue;
+        };
         // TODO Convert to physical pixels
-        let (computed_node, global_transform) = pos_query.get(content_node_id).unwrap();
         let content_node_size = computed_node.size();
 
         let node_position = global_transform.translation().xy();

--- a/crates/bevy_pane_layout/src/ui.rs
+++ b/crates/bevy_pane_layout/src/ui.rs
@@ -51,6 +51,7 @@ pub(crate) fn spawn_pane<'a>(
                 width: Val::Percent(100.),
                 height: Val::Px(27.),
                 align_items: AlignItems::Center,
+                flex_shrink: 0.,
                 ..default()
             },
             theme.pane_header_background_color,
@@ -93,6 +94,10 @@ pub(crate) fn spawn_pane<'a>(
             Text::new(name),
             TextFont {
                 font_size: 14.,
+                ..default()
+            },
+            Node {
+                flex_shrink: 0.,
                 ..default()
             },
         ));


### PR DESCRIPTION
- Fix the second issue in #102
- Prevent the pane header and pane header text from being squished with `flex_shrink: 0` 