### PR TITLE
Fix `AssetBrowserLocation` crash

### DIFF
--- a/bevy_editor_panes/bevy_asset_browser/src/directory_content.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/directory_content.rs
@@ -74,11 +74,14 @@ pub fn fetch_directory_content(
     let task = IoTaskPool::get().spawn(async move {
         let source = sources.get(location.source_id.unwrap()).unwrap();
         let reader = source.reader();
-        let mut dir_stream = reader
-            .read_directory(location.path.as_path())
-            .await
-            .unwrap();
+
         let mut content = DirectoryContent::default();
+        let dir_stream = reader.read_directory(location.path.as_path()).await;
+        if dir_stream.is_err() {
+            return content;
+        }
+        let mut dir_stream = dir_stream.unwrap();
+
         while let Some(entry) = dir_stream.next().await {
             let asset_type = if reader.is_directory(&entry).await.unwrap() {
                 AssetType::Directory


### PR DESCRIPTION
The `AssetBrowserLocation`was pointing to a non existing folder
This happend because `AssetSource::Default` is guaranty to exist even if there is no "assets" folder `AssetSource::Default` being the default value of the `AssetBrowserLocation`