### PR TITLE
Reduce footer height

### DIFF
--- a/bevy_widgets/bevy_footer_bar/src/lib.rs
+++ b/bevy_widgets/bevy_footer_bar/src/lib.rs
@@ -37,18 +37,9 @@ fn footer_setup(
         .insert((
             Node {
                 width: Val::Percent(100.0),
-                height: Val::Px(30.0),
-                display: Display::Flex,
-                flex_direction: FlexDirection::Row,
-                flex_basis: Val::Px(30.0),
-                justify_items: JustifyItems::Start,
+                height: Val::Px(20.0),
                 align_items: AlignItems::Center,
-                padding: UiRect {
-                    left: Val::Px(5.0),
-                    right: Val::Px(5.0),
-                    top: Val::Px(0.0),
-                    bottom: Val::Px(0.0),
-                },
+                padding: UiRect::axes(Val::Px(5.0), Val::Px(0.0)),
                 ..Default::default()
             },
             theme.background_color,


### PR DESCRIPTION
- Reduced footer height to `20px`. This is the height used by both VS Code and Blender
- Cleaned up some unused style parameters

### Showcase
Before
![image](https://github.com/user-attachments/assets/96a4cf86-5216-486c-889e-bdfdc36d2a90)

After
![image](https://github.com/user-attachments/assets/483258cf-6d9e-420e-92e4-3959d5288d6d)