### PR TITLE
Add menu item for loading GLTF files

### DIFF
--- a/crates/bevy_editor/Cargo.toml
+++ b/crates/bevy_editor/Cargo.toml
@@ -11,6 +11,8 @@ bevy_footer_bar.workspace = true
 bevy_context_menu.workspace = true
 bevy_editor_styles.workspace = true
 
+rfd.workspace = true
+
 # Panes
 bevy_3d_viewport.workspace = true
 bevy_2d_viewport.workspace = true

--- a/crates/bevy_editor/src/load_gltf.rs
+++ b/crates/bevy_editor/src/load_gltf.rs
@@ -1,0 +1,73 @@
+//! This is a temporary solution for loading GLTF scenes into the editor.
+
+use bevy::{
+    prelude::*,
+    tasks::{block_on, futures_lite::future, AsyncComputeTaskPool, Task},
+};
+use rfd::{AsyncFileDialog, FileHandle};
+
+pub(crate) struct LoadGltfPlugin;
+
+impl Plugin for LoadGltfPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<GltfFilepickerTask>()
+            .add_systems(Update, (pick_gltf, poll_pick_gltf, file_dropped));
+    }
+}
+
+fn file_dropped(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut event_reader: EventReader<FileDragAndDrop>,
+) {
+    for event in event_reader.read() {
+        if let FileDragAndDrop::DroppedFile { path_buf, .. } = event {
+            let asset_path = GltfAssetLabel::Scene(0).from_asset(path_buf.clone());
+            commands.spawn(SceneRoot(asset_server.load(asset_path)));
+        }
+    }
+}
+
+#[derive(Resource, Default)]
+pub(crate) struct GltfFilepickerTask(Option<Task<Option<FileHandle>>>);
+
+pub(crate) fn pick_gltf(
+    mut file_picker_task: ResMut<GltfFilepickerTask>,
+    keyboard_input: Res<ButtonInput<KeyCode>>,
+) {
+    if file_picker_task.0.is_some() {
+        return;
+    }
+
+    if keyboard_input.pressed(KeyCode::ControlLeft) && keyboard_input.just_pressed(KeyCode::KeyL) {
+        file_picker_task.0 = Some(
+            AsyncComputeTaskPool::get().spawn(
+                AsyncFileDialog::new()
+                    .set_title("Load GLTF file")
+                    .add_filter("gltf/glb", &["gltf", "glb"])
+                    .pick_file(),
+            ),
+        );
+    }
+}
+
+fn poll_pick_gltf(
+    mut file_picker_task: ResMut<GltfFilepickerTask>,
+    asset_server: Res<AssetServer>,
+    mut commands: Commands,
+) {
+    let Some(task) = &mut file_picker_task.0 else {
+        return;
+    };
+
+    let Some(result) = block_on(future::poll_once(task)) else {
+        return;
+    };
+    file_picker_task.0 = None;
+
+    if let Some(file) = result {
+        let path = file.path().to_owned();
+        let asset_path = GltfAssetLabel::Scene(0).from_asset(path);
+        commands.spawn(SceneRoot(asset_server.load(asset_path)));
+    }
+}

--- a/crates/bevy_editor/src/main.rs
+++ b/crates/bevy_editor/src/main.rs
@@ -21,6 +21,9 @@ use bevy_2d_viewport::Viewport2dPanePlugin;
 use bevy_3d_viewport::Viewport3dPanePlugin;
 use bevy_asset_browser::AssetBrowserPanePlugin;
 
+use crate::load_gltf::LoadGltfPlugin;
+
+mod load_gltf;
 mod ui;
 
 fn main() {
@@ -39,6 +42,7 @@ fn main() {
             Viewport3dPanePlugin,
             ui::EditorUIPlugin,
             AssetBrowserPanePlugin,
+            LoadGltfPlugin,
         ))
         .add_systems(Startup, setup)
         .run();
@@ -56,12 +60,15 @@ fn setup(
     ));
 
     commands.spawn((
-        Mesh3d(meshes.add(Cuboid::from_length(1.0))),
+        Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(1.5)))),
         MeshMaterial3d(materials_3d.add(Color::WHITE)),
     ));
 
     commands.spawn((
-        DirectionalLight::default(),
+        DirectionalLight {
+            shadows_enabled: true,
+            ..default()
+        },
         Transform::default().looking_to(Vec3::NEG_ONE, Vec3::Y),
     ));
 }


### PR DESCRIPTION
I originally wanted to integrate this into the asset browser, but that is tricky and needs more design work.
So, instead you can:
* Press `Ctrl + L` to `L`oad a file via the native file-picker, or
* Load a file by dropping it on the window
  Note: Not supported on wayland: https://github.com/rust-windowing/winit/issues/1881

if a file is loaded then the first scene in that file will be spawned.

I've replaced the default cube with a plane to it doesn't overlap with the loaded scene, and shadows are now enabled on the directional light.

### Showcase
![image](https://github.com/user-attachments/assets/57525e3c-a3fc-4d19-acb5-d2b73790f1e4)

### Future Work
- This is temporary. We shouldn't load GTLF files directly, we should import them and then we can load them from the asset browser.
- We need a way to add 'actions' to asset types in the asset browser