### PR TITLE
Use lighter grid colors

### DIFF
--- a/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
@@ -69,8 +69,8 @@ fn setup(mut commands: Commands, theme: Res<Theme>) {
             scale: 0.01,
             dot_fadeout_strength: 0.,
             z_axis_color: Color::srgb(0.2, 8., 0.3),
-            major_line_color: theme.general.background_color.0,
-            minor_line_color: theme.pane.header_background_color.0,
+            major_line_color: theme.viewport.grid_major_line_color,
+            minor_line_color: theme.viewport.grid_minor_line_color,
             ..default()
         },
         Transform::from_rotation(Quat::from_rotation_arc(Vec3::Y, Vec3::Z)),

--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -131,8 +131,8 @@ fn setup(mut commands: Commands, theme: Res<Theme>) {
     commands.spawn((
         InfiniteGrid,
         InfiniteGridSettings {
-            major_line_color: theme.general.background_color.0,
-            minor_line_color: theme.pane.header_background_color.0,
+            major_line_color: theme.viewport.grid_major_line_color,
+            minor_line_color: theme.viewport.grid_minor_line_color,
             ..default()
         },
         RenderLayers::layer(1),

--- a/crates/bevy_editor_styles/src/lib.rs
+++ b/crates/bevy_editor_styles/src/lib.rs
@@ -142,8 +142,8 @@ impl FromWorld for Theme {
             },
             viewport: ViewportStyles {
                 background_color: Color::oklch(0.3677, 0.0, 0.0),
-                grid_major_line_color: Color::oklch(0.5, 0.0, 0.0),
-                grid_minor_line_color: Color::oklch(0.425, 0.0, 0.0),
+                grid_major_line_color: Color::oklch(0.45, 0.0, 0.0),
+                grid_minor_line_color: Color::oklch(0.4, 0.0, 0.0),
             },
             scroll_box: ScrollBoxStyles {
                 background_color: BackgroundColor(Color::oklch(0.4, 0.0, 0.0)),

--- a/crates/bevy_editor_styles/src/lib.rs
+++ b/crates/bevy_editor_styles/src/lib.rs
@@ -92,6 +92,10 @@ pub struct ContextMenuStyles {
 pub struct ViewportStyles {
     /// The background color of the viewports.
     pub background_color: Color,
+    /// The color of the major grid lines.
+    pub grid_major_line_color: Color,
+    /// The color of the minor grid lines.
+    pub grid_minor_line_color: Color,
 }
 
 /// The styles for the scroll boxes in the editor.
@@ -138,6 +142,8 @@ impl FromWorld for Theme {
             },
             viewport: ViewportStyles {
                 background_color: Color::oklch(0.3677, 0.0, 0.0),
+                grid_major_line_color: Color::oklch(0.5, 0.0, 0.0),
+                grid_minor_line_color: Color::oklch(0.425, 0.0, 0.0),
             },
             scroll_box: ScrollBoxStyles {
                 background_color: BackgroundColor(Color::oklch(0.4, 0.0, 0.0)),


### PR DESCRIPTION
The current grid colors are *darker* than the viewport background.

![kuva](https://github.com/user-attachments/assets/3c2229ac-af6b-4020-829e-69a58adf721b)

![kuva](https://github.com/user-attachments/assets/73ffaea3-367e-4157-800a-3671ccfdfa76)

These are distracting and don't look great. If we look at almost any other tool or editor, like Blender or Godot, the grid lines are lighter:

![kuva](https://github.com/user-attachments/assets/1d8d708e-8e34-4da4-9b44-785ace95c245)

![kuva](https://github.com/user-attachments/assets/3cde6b8a-341d-49cf-8b1d-cc358752ed9d)

## Solution

Add grid line color configuration to `ViewportStyles`, and make the lines lighter and less distracting.

![kuva](https://github.com/user-attachments/assets/583e4f5b-6e83-4f73-8546-8e9d78a53567)

![kuva](https://github.com/user-attachments/assets/49f8be89-ff80-4ec4-99ac-4eb387732e72)