### PR TITLE
Change Z axis color

### DIFF
--- a/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
@@ -68,7 +68,8 @@ fn setup(mut commands: Commands, theme: Res<Theme>) {
         InfiniteGridSettings {
             scale: 0.01,
             dot_fadeout_strength: 0.,
-            z_axis_color: Color::srgb(0.2, 8., 0.3),
+            x_axis_color: theme.viewport.x_axis_color,
+            z_axis_color: theme.viewport.y_axis_color,
             major_line_color: theme.viewport.grid_major_line_color,
             minor_line_color: theme.viewport.grid_minor_line_color,
             ..default()

--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -131,6 +131,8 @@ fn setup(mut commands: Commands, theme: Res<Theme>) {
     commands.spawn((
         InfiniteGrid,
         InfiniteGridSettings {
+            x_axis_color: theme.viewport.x_axis_color,
+            z_axis_color: theme.viewport.z_axis_color,
             major_line_color: theme.viewport.grid_major_line_color,
             minor_line_color: theme.viewport.grid_minor_line_color,
             ..default()

--- a/crates/bevy_editor_styles/src/lib.rs
+++ b/crates/bevy_editor_styles/src/lib.rs
@@ -92,6 +92,12 @@ pub struct ContextMenuStyles {
 pub struct ViewportStyles {
     /// The background color of the viewports.
     pub background_color: Color,
+    /// The color of the x-axis.
+    pub x_axis_color: Color,
+    /// The color of the y-axis.
+    pub y_axis_color: Color,
+    /// The color of the z-axis.
+    pub z_axis_color: Color,
     /// The color of the major grid lines.
     pub grid_major_line_color: Color,
     /// The color of the minor grid lines.
@@ -142,6 +148,9 @@ impl FromWorld for Theme {
             },
             viewport: ViewportStyles {
                 background_color: Color::oklch(0.3677, 0.0, 0.0),
+                x_axis_color: Color::oklch(0.65, 0.24, 27.0),
+                y_axis_color: Color::oklch(0.87, 0.27, 144.0),
+                z_axis_color: Color::oklch(0.65, 0.19, 255.0),
                 grid_major_line_color: Color::oklch(0.45, 0.0, 0.0),
                 grid_minor_line_color: Color::oklch(0.4, 0.0, 0.0),
             },

--- a/crates/bevy_infinite_grid/src/lib.rs
+++ b/crates/bevy_infinite_grid/src/lib.rs
@@ -42,8 +42,8 @@ pub struct InfiniteGridSettings {
 impl Default for InfiniteGridSettings {
     fn default() -> Self {
         Self {
-            x_axis_color: Color::srgb(1.0, 0.2, 0.2),
-            z_axis_color: Color::srgb(0.175, 0.55, 1.0),
+            x_axis_color: Color::oklch(0.65, 0.24, 27.0),
+            z_axis_color: Color::oklch(0.65, 0.19, 255.0),
             minor_line_color: Color::srgb(0.1, 0.1, 0.1),
             major_line_color: Color::srgb(0.25, 0.25, 0.25),
             fadeout_distance: 100.,

--- a/crates/bevy_infinite_grid/src/lib.rs
+++ b/crates/bevy_infinite_grid/src/lib.rs
@@ -43,7 +43,7 @@ impl Default for InfiniteGridSettings {
     fn default() -> Self {
         Self {
             x_axis_color: Color::srgb(1.0, 0.2, 0.2),
-            z_axis_color: Color::srgb(0.2, 0.2, 1.0),
+            z_axis_color: Color::srgb(0.175, 0.55, 1.0),
             minor_line_color: Color::srgb(0.1, 0.1, 0.1),
             major_line_color: Color::srgb(0.25, 0.25, 0.25),
             fadeout_distance: 100.,


### PR DESCRIPTION
The current Z axis color is way too saturated and hard on the eyes, and its perceived lightness is much lower than lightness of the red axis.

![kuva](https://github.com/user-attachments/assets/4c15e5da-ebcd-4c38-8e76-baed7dbe8ef6)

In most other tools and editor, like Godot and Blender, the Z axis uses a lighter blue.

![kuva](https://github.com/user-attachments/assets/bb8772de-725b-4707-97e2-3d4b945a7676)

![kuva](https://github.com/user-attachments/assets/82a136c0-9ccc-4070-88f5-60f173cd0a74)

## Solution

Change the axis color to a lighter blue that is close to the color used by Godot and Blender.

![kuva](https://github.com/user-attachments/assets/594ad0c3-82d6-487a-922e-f82da9cc1855)