### PR TITLE
Infinite scaling grid

### DIFF
--- a/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
@@ -66,7 +66,7 @@ fn setup(mut commands: Commands, theme: Res<Theme>) {
     commands.spawn((
         InfiniteGrid,
         InfiniteGridSettings {
-            scale: 0.01,
+            scale: 100.,
             dot_fadeout_strength: 0.,
             x_axis_color: theme.viewport.x_axis_color,
             z_axis_color: theme.viewport.y_axis_color,

--- a/crates/bevy_infinite_grid/examples/simple_2d.rs
+++ b/crates/bevy_infinite_grid/examples/simple_2d.rs
@@ -14,7 +14,7 @@ fn setup_system(mut commands: Commands) {
     commands.spawn((
         InfiniteGrid,
         InfiniteGridSettings {
-            scale: 0.01,
+            scale: 100.,
             dot_fadeout_strength: 0.,
             z_axis_color: Color::srgb(0.2, 8., 0.3),
             ..default()


### PR DESCRIPTION
The infinite grids now also scale infinitely when you zoom out!*
<sub>*Until they disintegrate due to floating point error</sub>

I've reworked the meaning of the grids `scale` value too. It now means 'world units per grid square' at the lowest scaling.
`fadeout_distance` is now also relative to the scaling.

### Future Work
- The transition is currently instantaneous and a bit jarring, this could be smoothed out
