### PR TITLE
Add basic glossary

### DIFF
--- a/design-book/src/SUMMARY.md
+++ b/design-book/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Vision](./vision.md)
 - [Roadmap](./roadmap.md)
+- [Glossary](./glossary.md)
 - [Design Constraints](./design-constraints.md)
 - [Human Interface Guidelines](./human-interface-guidelines.md)
   - [Design Paradigms](./design-paradigms.md)

--- a/design-book/src/glossary.md
+++ b/design-book/src/glossary.md
@@ -1,6 +1,6 @@
 # Glossary
 
-- **View**: Provides a specific view of the data, displayed within designated layout Areas. Some common views include the 3D Viewport, Scene Tree, and Entity Inspector.
-- **Area**: Rectangular sections dividing the window, each allocated to one or more Views.
+- **View**: Provides a specific view of the data, displayed within designated layout Panes. Some common views include the 3D Viewport, Scene Tree, and Entity Inspector.
+- **Pane**: Rectangular sections dividing the window, each allocated to one or more Views.
 - **Region**: Rectangular sub-sections within Views, each serving a distinct purpose or function.
-- **Workspace**: A layout preset that organizes the window into Areas, each containing specific Views.
+- **Workspace**: A layout preset that organizes the window into Panes, each containing specific Views.

--- a/design-book/src/glossary.md
+++ b/design-book/src/glossary.md
@@ -1,0 +1,6 @@
+# Glossary
+
+- **Tool**: Provides a specific view of the data, displayed within designated layout Areas. Some common tools include the 3D viewport, scene tree, and entity inspector.
+- **Area**: Rectangular sections dividing the window, each allocated to one or more Tools.
+- **Region**: Rectangular sub-sections within Tools, each serving a distinct purpose or function.
+- **Workspace**: A layout preset that organizes the window into Areas, each containing specific Tools.

--- a/design-book/src/glossary.md
+++ b/design-book/src/glossary.md
@@ -1,6 +1,6 @@
 # Glossary
 
-- **Tool**: Provides a specific view of the data, displayed within designated layout Areas. Some common tools include the 3D viewport, scene tree, and entity inspector.
-- **Area**: Rectangular sections dividing the window, each allocated to one or more Tools.
-- **Region**: Rectangular sub-sections within Tools, each serving a distinct purpose or function.
-- **Workspace**: A layout preset that organizes the window into Areas, each containing specific Tools.
+- **View**: Provides a specific view of the data, displayed within designated layout Areas. Some common views include the 3D Viewport, Scene Tree, and Entity Inspector.
+- **Area**: Rectangular sections dividing the window, each allocated to one or more Views.
+- **Region**: Rectangular sub-sections within Views, each serving a distinct purpose or function.
+- **Workspace**: A layout preset that organizes the window into Areas, each containing specific Views.


### PR DESCRIPTION
Add a basic Glossary page. Initially based on Blender terms, changed after some discussion.

Once we decide in some basic terms we can update the whole prototype docs in a follow-up PR.