### PR TITLE
Splitting runtime and editor into separate plugins

### DIFF
--- a/bevy_widgets/bevy_scroll_box/src/lib.rs
+++ b/bevy_widgets/bevy_scroll_box/src/lib.rs
@@ -300,7 +300,6 @@ fn update_scroll_bars(
     query_children: Query<&Children>,
     mut query_node: Query<&mut Node>,
 ) {
-    let mut i = 0;
     for (scrollbox, scrollbox_computed, scrollbox_children) in query_scrollboxes.iter() {
         let content_children = query_scrollbox_content
             .get(scrollbox_children[0])
@@ -321,11 +320,6 @@ fn update_scroll_bars(
                 (height, pos)
             };
 
-            println!(
-                "UPDATE {}: {}/{} = {}",
-                i, scrollbox_height, content_height, handle_height
-            );
-            i += 1;
             {
                 let mut scrollbar_node = query_node.get_mut(scrollbox_children[1]).unwrap();
                 if handle_height == 100.0 {

--- a/crates/bevy_editor/src/lib.rs
+++ b/crates/bevy_editor/src/lib.rs
@@ -31,19 +31,44 @@ mod load_gltf;
 pub mod project;
 mod ui;
 
-/// The main application
-pub struct App {
-    window: Window,
+/// The plugin that handle the bare minimum to run the application
+pub struct RuntimePlugin;
+
+impl Plugin for RuntimePlugin {
+    fn build(&self, bevy_app: &mut BevyApp) {
+        bevy_app.add_plugins(DefaultPlugins);
+    }
 }
+
+/// The plugin that attach your editor to the application
+pub struct EditorPlugin;
+
+impl Plugin for EditorPlugin {
+    fn build(&self, bevy_app: &mut BevyApp) {
+        // Update/register this project to the editor project list
+        project::update_project_info();
+
+        bevy_app
+            .add_plugins((
+                ContextMenuPlugin,
+                StylesPlugin,
+                Viewport2dPanePlugin,
+                Viewport3dPanePlugin,
+                ui::EditorUIPlugin,
+                AssetBrowserPanePlugin,
+                LoadGltfPlugin,
+            ))
+            .add_systems(Startup, dummy_setup);
+    }
+}
+
+/// Your game application
+/// This appllication allow your game to run, and the editor to be attached to it
+pub struct App;
 
 impl Default for App {
     fn default() -> Self {
-        App {
-            window: Window {
-                title: "Bevy Editor".to_string(),
-                ..default()
-            },
-        }
+        App {}
     }
 }
 
@@ -53,50 +78,23 @@ impl App {
         Self::default()
     }
 
-    /// Set default window resolution/size
-    #[inline]
-    pub fn window_resolution(&mut self, resolution: WindowResolution) -> &mut Self {
-        self.window.resolution = resolution;
-        self
-    }
-
-    /// Set the window title
-    #[inline]
-    pub fn window_name(&mut self, name: &str) -> &mut Self {
-        self.window.title = name.to_string();
-        self
-    }
-
     /// Run the application
     pub fn run(&self) -> AppExit {
         let args = std::env::args().collect::<Vec<String>>();
         let editor_mode = !args.iter().any(|arg| arg == "-game");
 
         let mut bevy_app = BevyApp::new();
-        bevy_app.add_plugins(DefaultPlugins.set(WindowPlugin {
-            primary_window: Some(self.window.clone()),
-            ..default()
-        }));
+        bevy_app.add_plugins(RuntimePlugin);
         if editor_mode {
-            project::update_project_info();
-
-            bevy_app
-                .add_plugins((
-                    ContextMenuPlugin,
-                    StylesPlugin,
-                    Viewport2dPanePlugin,
-                    Viewport3dPanePlugin,
-                    ui::EditorUIPlugin,
-                    AssetBrowserPanePlugin,
-                    LoadGltfPlugin,
-                ))
-                .add_systems(Startup, setup);
+            bevy_app.add_plugins(EditorPlugin);
         }
+
         bevy_app.run()
     }
 }
 
-fn setup(
+/// This is temporary, until we can load maps from the asset browser
+fn dummy_setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials_2d: ResMut<Assets<ColorMaterial>>,

--- a/crates/bevy_editor/src/lib.rs
+++ b/crates/bevy_editor/src/lib.rs
@@ -16,7 +16,6 @@ use bevy::prelude::*;
 // Re-export Bevy for project use
 pub use bevy;
 
-use bevy::window::WindowResolution;
 use bevy_context_menu::ContextMenuPlugin;
 use bevy_editor_styles::StylesPlugin;
 
@@ -64,18 +63,13 @@ impl Plugin for EditorPlugin {
 
 /// Your game application
 /// This appllication allow your game to run, and the editor to be attached to it
+#[derive(Default)]
 pub struct App;
-
-impl Default for App {
-    fn default() -> Self {
-        App {}
-    }
-}
 
 impl App {
     /// create new instance of [`App`]
     pub fn new() -> Self {
-        Self::default()
+        Self
     }
 
     /// Run the application


### PR DESCRIPTION
Talking with you all about the Launcher made me realize that we need a proper way to separate between Runtime and Editor behaviours. Here is cleaner way to do this, than my old `if`, but it's essentially the same.

### Runtime
The `RuntimePlugin` contain the bare minimum for the game to run as a game, but more than the `bevy::app` because we might need to load/use thing that were created with the editor.
e.g. config files (once this feature is ready) that's a runtime plugin

### Editor
The `EditorPlugin` contain the default editor that we want to provide. (I recon it should be relatively small and the users can then use Plugin/PluginGroups to extend his functionality.
e.g scene_inspector, asset_browser, ... 

The good thing about plugins, is that we can make them configurable, and advance users would be able to make they're own App if they feel like it (without having to download the bevy_editor source code)