### PR TITLE
Adds an example to the launcher crate for developer sanity

### DIFF
--- a/crates/bevy_editor_launcher/examples/simple_editor.rs
+++ b/crates/bevy_editor_launcher/examples/simple_editor.rs
@@ -1,0 +1,5 @@
+use bevy_editor::App;
+
+fn main() {
+    App::new().run();
+}

--- a/crates/bevy_editor_launcher/examples/simple_editor.rs
+++ b/crates/bevy_editor_launcher/examples/simple_editor.rs
@@ -1,3 +1,4 @@
+//! A simple example of how to launch the editor.
 use bevy_editor::App;
 
 fn main() {


### PR DESCRIPTION
Simple, adds an example so we can run to see changes without messing with cargo and separate project files just to see a change on editor side.

Run via `cargo run --example simple_editor`