### PR TITLE
Add toggleable fullscreen panes item in roadmap

### DIFF
--- a/design-book/src/roadmap.md
+++ b/design-book/src/roadmap.md
@@ -95,6 +95,7 @@ It's best not to plan too far in advance!
   - [ ] Blender-style workspaces
   - [ ] context menus
   - [ ] command palette
+  - [ ] toggleable fullscreen panes
 - [ ] dedicated hotkeys and controls for the most common operations:
   - [ ] manipulating camera
   - [ ] modifying transforms


### PR DESCRIPTION
# What?

To add the ability to make a pane full screen

# Why?

To keep focus on task which is necessary and avoid any distraction
To make more space for editing for small resolution screen  

# Any Example?

Similar behavior to blender `CTRL+space` to make active  window full screen 