### PR TITLE
Pane registry improvements

### DIFF
--- a/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
@@ -11,19 +11,19 @@ use bevy::{
 use bevy_editor_camera::{EditorCamera2d, EditorCamera2dPlugin};
 use bevy_editor_styles::Theme;
 use bevy_infinite_grid::{InfiniteGrid, InfiniteGridPlugin, InfiniteGridSettings};
-use bevy_pane_layout::{PaneContentNode, PaneRegistry};
+use bevy_pane_layout::prelude::*;
 
 /// The identifier for the 2D Viewport.
 /// This is present on any pane that is a 2D Viewport.
 #[derive(Component)]
 pub struct Bevy2dViewport {
-    camera: Entity,
+    camera_id: Entity,
 }
 
 impl Default for Bevy2dViewport {
     fn default() -> Self {
         Bevy2dViewport {
-            camera: Entity::PLACEHOLDER,
+            camera_id: Entity::PLACEHOLDER,
         }
     }
 }
@@ -42,23 +42,18 @@ impl Plugin for Viewport2dPanePlugin {
                 PostUpdate,
                 update_render_target_size.after(ui_layout_system),
             )
-            .add_observer(on_pane_creation)
             .add_observer(
                 |trigger: Trigger<OnRemove, Bevy2dViewport>,
                  mut commands: Commands,
                  query: Query<&Bevy2dViewport>| {
                     // Despawn the viewport camera
                     commands
-                        .entity(query.get(trigger.entity()).unwrap().camera)
+                        .entity(query.get(trigger.entity()).unwrap().camera_id)
                         .despawn_recursive();
                 },
             );
 
-        app.world_mut()
-            .get_resource_or_init::<PaneRegistry>()
-            .register("Viewport 2D", |mut commands, pane_root| {
-                commands.entity(pane_root).insert(Bevy2dViewport::default());
-            });
+        app.register_pane("Viewport 2D", on_pane_creation);
     }
 }
 
@@ -80,20 +75,11 @@ fn setup(mut commands: Commands, theme: Res<Theme>) {
 }
 
 fn on_pane_creation(
-    trigger: Trigger<OnAdd, Bevy2dViewport>,
+    structure: In<PaneStructure>,
     mut commands: Commands,
-    children_query: Query<&Children>,
-    mut query: Query<&mut Bevy2dViewport>,
-    content: Query<&PaneContentNode>,
     mut images: ResMut<Assets<Image>>,
     theme: Res<Theme>,
 ) {
-    let pane_root = trigger.entity();
-    let content_node = children_query
-        .iter_descendants(pane_root)
-        .find(|e| content.contains(*e))
-        .unwrap();
-
     let mut image = Image::default();
 
     image.texture_descriptor.usage |= TextureUsages::RENDER_ATTACHMENT;
@@ -113,7 +99,7 @@ fn on_pane_creation(
                 ..default()
             },
         ))
-        .set_parent(content_node)
+        .set_parent(structure.content)
         .id();
 
     let camera_id = commands
@@ -146,7 +132,9 @@ fn on_pane_creation(
             },
         );
 
-    query.get_mut(pane_root).unwrap().camera = camera_id;
+    commands
+        .entity(structure.root)
+        .insert(Bevy2dViewport { camera_id });
 }
 
 fn update_render_target_size(
@@ -175,7 +163,7 @@ fn update_render_target_size(
         let node_position = global_transform.translation().xy();
         let rect = Rect::from_center_size(node_position, computed_node.size());
 
-        let (camera, mut editor_camera) = camera_query.get_mut(viewport.camera).unwrap();
+        let (camera, mut editor_camera) = camera_query.get_mut(viewport.camera_id).unwrap();
 
         editor_camera.viewport_override = Some(rect);
 

--- a/bevy_editor_panes/bevy_asset_browser/src/lib.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/lib.rs
@@ -11,9 +11,9 @@ use bevy::{
     },
     prelude::*,
 };
-use bevy_pane_layout::PaneRegistry;
+use bevy_pane_layout::prelude::*;
 use bevy_scroll_box::ScrollBoxPlugin;
-use ui::{top_bar::location_as_changed, AssetBrowserNode};
+use ui::top_bar::location_as_changed;
 
 mod io;
 mod ui;
@@ -27,11 +27,7 @@ impl Plugin for AssetBrowserPanePlugin {
         embedded_asset!(app, "assets/source_icon.png");
         embedded_asset!(app, "assets/file_icon.png");
 
-        app.world_mut()
-            .get_resource_or_init::<PaneRegistry>()
-            .register("Asset Browser", |mut commands, pane_root| {
-                commands.entity(pane_root).insert(AssetBrowserNode);
-            });
+        app.register_pane("Asset Browser", ui::on_pane_creation);
 
         // Fetch the AssetPlugin file path, this is used to create assets at the correct location
         let default_source_absolute_file_path = {
@@ -52,7 +48,6 @@ impl Plugin for AssetBrowserPanePlugin {
             .insert_resource(DefaultSourceFilePath(default_source_absolute_file_path))
             .insert_resource(AssetBrowserLocation::default())
             .insert_resource(DirectoryContent::default())
-            .add_observer(ui::on_pane_creation)
             .add_systems(Startup, io::task::fetch_directory_content)
             // .add_systems(Update, button_interaction)
             .add_systems(

--- a/bevy_editor_panes/bevy_asset_browser/src/ui/mod.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/ui/mod.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 use bevy_editor_styles::Theme;
-use bevy_pane_layout::PaneContentNode;
+use bevy_pane_layout::prelude::*;
 
 use crate::{AssetBrowserLocation, DirectoryContent};
 
@@ -17,23 +17,15 @@ pub struct AssetBrowserNode;
 /// Spawn [`AssetBrowserNode`] once the pane is created
 #[allow(clippy::too_many_arguments)]
 pub fn on_pane_creation(
-    trigger: Trigger<OnAdd, AssetBrowserNode>,
+    structure: In<PaneStructure>,
     mut commands: Commands,
     theme: Res<Theme>,
-    children_query: Query<&Children>,
-    content: Query<&PaneContentNode>,
     location: Res<AssetBrowserLocation>,
     asset_server: Res<AssetServer>,
     directory_content: Res<DirectoryContent>,
 ) {
-    let pane_root = trigger.entity();
-    let content_node = children_query
-        .iter_descendants(pane_root)
-        .find(|e| content.contains(*e))
-        .unwrap();
-
     let asset_browser = commands
-        .entity(content_node)
+        .entity(structure.content)
         .insert(Node {
             width: Val::Percent(100.0),
             height: Val::Percent(100.0),
@@ -52,6 +44,8 @@ pub fn on_pane_creation(
         &location,
     )
     .set_parent(asset_browser);
+
+    commands.entity(structure.root).insert(AssetBrowserNode);
 }
 
 pub(crate) const DEFAULT_SOURCE_ID_NAME: &str = "Default";

--- a/crates/bevy_pane_layout/src/lib.rs
+++ b/crates/bevy_pane_layout/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod handlers;
 mod pane_drop_area;
+pub mod registry;
 mod ui;
 
 /// The Bevy Pane Layout system.
@@ -20,33 +21,40 @@ mod ui;
 use bevy::prelude::*;
 use bevy_editor_styles::Theme;
 
-use crate::ui::{spawn_divider, spawn_pane, spawn_resize_handle};
+use crate::{
+    registry::{PaneAppExt, PaneRegistryPlugin, PaneStructure},
+    ui::{spawn_divider, spawn_pane, spawn_resize_handle},
+};
+
+/// Crate prelude.
+pub mod prelude {
+    pub use crate::{
+        registry::{PaneAppExt, PaneStructure},
+        PaneAreaNode, PaneContentNode, PaneHeaderNode,
+    };
+}
 
 /// The Bevy Pane Layout Plugin.
 pub struct PaneLayoutPlugin;
 
 impl Plugin for PaneLayoutPlugin {
     fn build(&self, app: &mut App) {
-        let mut pane_registry = app.world_mut().get_resource_or_init::<PaneRegistry>();
-
         // TODO Move these registrations to their respective crates.
-        pane_registry.register("Properties", |mut _commands, _pane_root| {
+        app.register_pane("Properties", |_pane_structure: In<PaneStructure>| {
             // Todo
         });
 
-        pane_registry.register("Scene Tree", |mut _commands, _pane_root| {
+        app.register_pane("Scene Tree", |_pane_structure: In<PaneStructure>| {
             // Todo
         });
 
-        app.init_resource::<DragState>()
-            .init_resource::<PaneRegistry>()
+        app.add_plugins(PaneRegistryPlugin)
+            .init_resource::<DragState>()
             .add_systems(Startup, setup.in_set(PaneLayoutSet))
             .add_systems(
                 Update,
-                (
-                    (cleanup_divider_single_child, apply_size).chain(),
-                    on_pane_creation,
-                )
+                (cleanup_divider_single_child, apply_size)
+                    .chain()
                     .in_set(PaneLayoutSet),
             );
     }
@@ -87,56 +95,9 @@ struct DragState {
     parent_node_size: f32,
 }
 
-fn on_pane_creation(
-    mut query: Query<(Entity, &PaneRootNode), Added<PaneRootNode>>,
-    mut pane_registry: ResMut<PaneRegistry>,
-    mut commands: Commands,
-) {
-    for (entity, pane_root) in &mut query {
-        let pane = pane_registry
-            .panes
-            .iter_mut()
-            .find(|pane| pane.name == pane_root.name);
-
-        if let Some(pane) = pane {
-            (pane.creation_callback)(commands.reborrow(), entity);
-        } else {
-            warn!(
-                "No pane found in the registry with name: '{}'",
-                pane_root.name
-            );
-        }
-    }
-}
-
 /// System Set to set up the Pane Layout.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PaneLayoutSet;
-
-/// A registry of pane types.
-#[derive(Resource, Default)]
-pub struct PaneRegistry {
-    panes: Vec<Pane>,
-}
-
-impl PaneRegistry {
-    /// Register a new pane type.
-    pub fn register(
-        &mut self,
-        name: impl Into<String>,
-        creation_callback: impl FnMut(Commands, Entity) + Send + Sync + 'static,
-    ) {
-        self.panes.push(Pane {
-            name: name.into(),
-            creation_callback: Box::new(creation_callback),
-        });
-    }
-}
-
-struct Pane {
-    name: String,
-    creation_callback: Box<dyn FnMut(Commands, Entity) + Send + Sync>,
-}
 
 // TODO There is no way to save or load layouts at this moment.
 // The setup system currently just creates a default layout at startup.

--- a/crates/bevy_pane_layout/src/registry.rs
+++ b/crates/bevy_pane_layout/src/registry.rs
@@ -1,0 +1,109 @@
+//! [`PaneRegistry`] module.
+
+use bevy::{
+    ecs::system::{BoxedSystem, SystemId},
+    prelude::*,
+    utils::HashMap,
+};
+
+use crate::{PaneLayoutSet, PaneRootNode};
+
+pub(crate) struct PaneRegistryPlugin;
+
+impl Plugin for PaneRegistryPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<PaneRegistry>()
+            .add_systems(Update, on_pane_creation.in_set(PaneLayoutSet));
+    }
+}
+
+/// A registry of pane types.
+#[derive(Resource, Default)]
+pub struct PaneRegistry {
+    panes: Vec<Pane>,
+}
+
+/// The node structure of a pane.
+#[derive(Component, Clone, Copy)]
+pub struct PaneStructure {
+    /// The root of the pane.
+    pub root: Entity,
+    /// The area node. Child of the root node.
+    pub area: Entity,
+    /// The header node. Child of the area node.
+    pub header: Entity,
+    /// The content node. Child of the area node.
+    pub content: Entity,
+}
+
+impl PaneRegistry {
+    /// Register a new pane type.
+    pub fn register<M>(
+        &mut self,
+        name: impl Into<String>,
+        system: impl IntoSystem<In<PaneStructure>, (), M>,
+    ) {
+        self.panes.push(Pane {
+            name: name.into(),
+            creation_callback: Some(Box::new(IntoSystem::into_system(system))),
+        });
+    }
+}
+
+struct Pane {
+    name: String,
+    creation_callback: Option<BoxedSystem<In<PaneStructure>>>,
+}
+
+pub(crate) fn on_pane_creation(
+    world: &mut World,
+    roots_query: &mut QueryState<Entity, Added<PaneRootNode>>,
+    pane_root_node_query: &mut QueryState<(&PaneRootNode, &PaneStructure)>,
+    mut system_ids: Local<HashMap<String, SystemId<In<PaneStructure>>>>,
+) {
+    let roots: Vec<_> = roots_query.iter(world).collect();
+    for entity in roots {
+        world.resource_scope(|world, mut pane_registry: Mut<PaneRegistry>| {
+            let (pane_root, &structure) = pane_root_node_query.get(world, entity).unwrap();
+            let pane = pane_registry
+                .panes
+                .iter_mut()
+                .find(|pane| pane.name == pane_root.name);
+
+            if let Some(pane) = pane {
+                let id = system_ids.entry(pane.name.clone()).or_insert_with(|| {
+                    world.register_boxed_system(pane.creation_callback.take().unwrap())
+                });
+
+                world.run_system_with_input(*id, structure).unwrap();
+            } else {
+                warn!(
+                    "No pane found in the registry with name: '{}'",
+                    pane_root.name
+                );
+            }
+        });
+    }
+}
+
+/// Extension trait for [`App`].
+pub trait PaneAppExt {
+    /// Register a new pane type.
+    fn register_pane<M>(
+        &mut self,
+        name: impl Into<String>,
+        system: impl IntoSystem<In<PaneStructure>, (), M>,
+    );
+}
+
+impl PaneAppExt for App {
+    fn register_pane<M>(
+        &mut self,
+        name: impl Into<String>,
+        system: impl IntoSystem<In<PaneStructure>, (), M>,
+    ) {
+        self.world_mut()
+            .get_resource_or_init::<PaneRegistry>()
+            .register(name, system);
+    }
+}

--- a/crates/bevy_pane_layout/src/ui.rs
+++ b/crates/bevy_pane_layout/src/ui.rs
@@ -3,8 +3,8 @@ use bevy_context_menu::{ContextMenu, ContextMenuOption};
 use bevy_editor_styles::Theme;
 
 use crate::{
-    handlers::*, Divider, DragState, PaneAreaNode, PaneContentNode, PaneHeaderNode, PaneRootNode,
-    ResizeHandle, Size,
+    handlers::*, registry::PaneStructure, Divider, DragState, PaneAreaNode, PaneContentNode,
+    PaneHeaderNode, PaneRootNode, ResizeHandle, Size,
 };
 
 pub(crate) fn spawn_pane<'a>(
@@ -44,7 +44,7 @@ pub(crate) fn spawn_pane<'a>(
         .id();
 
     // Header
-    commands
+    let header = commands
         .spawn((
             Node {
                 padding: UiRect::axes(Val::Px(5.), Val::Px(3.)),
@@ -115,10 +115,11 @@ pub(crate) fn spawn_pane<'a>(
                     ..default()
                 },
             ));
-        });
+        })
+        .id();
 
     // Content
-    commands
+    let content = commands
         .spawn((
             Node {
                 flex_grow: 1.,
@@ -126,7 +127,15 @@ pub(crate) fn spawn_pane<'a>(
             },
             PaneContentNode,
         ))
-        .set_parent(area);
+        .set_parent(area)
+        .id();
+
+    commands.entity(root).insert(PaneStructure {
+        root,
+        area,
+        header,
+        content,
+    });
 
     commands.entity(root)
 }


### PR DESCRIPTION
Before
```rs
app.add_observer(on_pane_creation)
    .world_mut()
    .get_resource_or_init::<PaneRegistry>()
    .register("Viewport 2D", |mut commands, pane_root| {
        commands.entity(pane_root).insert(Bevy2dViewport::default());
    });

// Pane setup system
fn on_pane_creation(trigger: Trigger<OnAdd, Bevy2dViewport>, ... 
```
After
```rs
app.register_pane("Viewport 2D", on_pane_creation);

// Pane setup system
fn on_pane_creation(structure: In<PaneStructure>, ...
```
Where `PaneStructure` is:
```rs
/// The node structure of a pane.
pub struct PaneStructure {
    /// The root of the pane.
    pub root: Entity,
    /// The area node. Child of the root node.
    pub area: Entity,
    /// The header node. Child of the area node.
    pub header: Entity,
    /// The content node. Child of the area node.
    pub content: Entity,
}
```