### PR TITLE
Simplify context menu bugfix + option border radius adjustment

### DIFF
--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -54,7 +54,7 @@ pub(crate) fn spawn_option<'a>(
                 flex_grow: 1.,
                 ..default()
             },
-            theme.button.border_radius,
+            theme.context_menu.option_border_radius,
         ))
         .observe(
             |trigger: Trigger<Pointer<Over>>,

--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -1,7 +1,7 @@
 use bevy::{prelude::*, window::SystemCursorIcon, winit::cursor::CursorIcon};
 use bevy_editor_styles::Theme;
 
-use crate::{ContextMenu, OpenedContextMenu};
+use crate::ContextMenu;
 
 pub(crate) fn spawn_context_menu<'a>(
     commands: &'a mut Commands,
@@ -92,16 +92,13 @@ pub(crate) fn spawn_option<'a>(
             move |trigger: Trigger<Pointer<Up>>,
                   mut commands: Commands,
                   parent_query: Query<&Parent>,
-                  mut query: Query<&mut ContextMenu>,
-                  mut opened_context_menu: ResMut<OpenedContextMenu>| {
+                  mut query: Query<&mut ContextMenu>| {
                 // Despawn the context menu when an option is selected
                 let root = parent_query
                     .iter_ancestors(trigger.entity())
                     .last()
                     .unwrap();
                 commands.entity(root).despawn_recursive();
-                // Invalidate opened context menu
-                *opened_context_menu = OpenedContextMenu(None);
 
                 // Run the option callback
                 let callback = &mut query.get_mut(target).unwrap().options[index].f;

--- a/crates/bevy_editor_styles/src/lib.rs
+++ b/crates/bevy_editor_styles/src/lib.rs
@@ -86,6 +86,8 @@ pub struct ContextMenuStyles {
     pub background_color: BackgroundColor,
     /// The hover color of the context menu.
     pub hover_color: BackgroundColor,
+    /// The border radius of the context menu options.
+    pub option_border_radius: BorderRadius,
 }
 
 /// The styles for viewports in the editor.
@@ -145,6 +147,7 @@ impl FromWorld for Theme {
             context_menu: ContextMenuStyles {
                 background_color: BackgroundColor(Color::oklch(0.209, 0., 0.)),
                 hover_color: BackgroundColor(Color::oklch(0.3677, 0., 0.)),
+                option_border_radius: BorderRadius::all(Val::Px(5.)),
             },
             viewport: ViewportStyles {
                 background_color: Color::oklch(0.3677, 0.0, 0.0),


### PR DESCRIPTION
The context menu bugfix from https://github.com/bevyengine/bevy_editor_prototypes/pull/143 was rather complicated. Here it is replaced with a `trigger.propagate(false);` call to prevent the right click event from bubbling up further when a context menu is opened.

I've also separated the context-menu option border-radius from general buttons and adjusted it to look right.

![image](https://github.com/user-attachments/assets/313bf87e-1d65-48a5-8f92-cf73baf1db85)
