### PR TITLE
Add `bevy_editor_core` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ bevy_toolbar = { path = "bevy_widgets/bevy_toolbar" }
 bevy_tooltips = { path = "bevy_widgets/bevy_tooltips" }
 
 # general crates
+bevy_editor_core = { path = "crates/bevy_editor_core" }
 bevy_asset_preview = { path = "crates/bevy_asset_preview" }
 bevy_editor = { path = "crates/bevy_editor" }
 bevy_editor_camera = { path = "crates/bevy_editor_camera" }

--- a/bevy_editor_panes/bevy_scene_tree/Cargo.toml
+++ b/bevy_editor_panes/bevy_scene_tree/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bevy.workspace = true
+bevy_editor_core.workspace = true
 bevy_pane_layout.workspace = true
 bevy_i-cant-believe-its-not-bsn.workspace = true
 

--- a/bevy_editor_panes/bevy_scene_tree/src/lib.rs
+++ b/bevy_editor_panes/bevy_scene_tree/src/lib.rs
@@ -11,6 +11,7 @@ use bevy::{
     picking::focus::PickingInteraction,
     prelude::*,
 };
+use bevy_editor_core::SelectedEntity;
 use bevy_i_cant_believe_its_not_bsn::WithChild;
 use bevy_pane_layout::prelude::{PaneAppExt, PaneStructure};
 use std::ops::Deref;
@@ -22,7 +23,7 @@ impl Plugin for SceneTreePlugin {
     fn build(&self, app: &mut App) {
         app.register_pane("Scene Tree", setup_pane);
 
-        app.init_resource::<SelectedEntity>().add_systems(
+        app.add_systems(
             PostUpdate,
             (
                 reset_selected_entity_if_entity_despawned,
@@ -55,12 +56,6 @@ fn setup_pane(pane: In<PaneStructure>, mut commands: Commands) {
             },
         );
 }
-
-/// The currently selected entity in the scene.
-// TODO: Move to a different crate so that it can be controlled by things like mesh picking
-// and accessed by the inspector without depending on this crate.
-#[derive(Resource, Default)]
-pub struct SelectedEntity(Option<Entity>);
 
 fn reset_selected_entity_if_entity_despawned(
     mut selected_entity: ResMut<SelectedEntity>,

--- a/crates/bevy_editor_core/Cargo.toml
+++ b/crates/bevy_editor_core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bevy_editor_core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bevy.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bevy_editor_core/src/lib.rs
+++ b/crates/bevy_editor_core/src/lib.rs
@@ -1,0 +1,18 @@
+//! This crate provides core functionality for the Bevy Engine Editor.
+
+use bevy::prelude::*;
+
+/// Plugin for the editor scene tree pane.
+pub struct EditorCorePlugin;
+
+impl Plugin for EditorCorePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<SelectedEntity>()
+            .register_type::<SelectedEntity>();
+    }
+}
+
+/// The currently selected entity in the scene.
+#[derive(Resource, Default, Reflect)]
+#[reflect(Resource, Default)]
+pub struct SelectedEntity(pub Option<Entity>);


### PR DESCRIPTION
We need a crate to house things all other crates depend on.

- Added `bevy_editor_core` crate
- Moved `SelectedEntity` into `bevy_editor_core`