### PR TITLE
small improvements and a "bugfix" | context menus

### DIFF
--- a/bevy_widgets/bevy_context_menu/src/lib.rs
+++ b/bevy_widgets/bevy_context_menu/src/lib.rs
@@ -17,7 +17,7 @@ impl Plugin for ContextMenuPlugin {
 }
 
 fn on_secondary_button_down_entity_with_context_menu(
-    mut trigger: Trigger<Pointer<Down>>,
+    mut trigger: Trigger<Pointer<Up>>,
     mut commands: Commands,
     query: Query<&ContextMenu>,
     theme: Res<Theme>,

--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -94,15 +94,17 @@ pub(crate) fn spawn_option<'a>(
                   parent_query: Query<&Parent>,
                   mut query: Query<&mut ContextMenu>| {
                 // Despawn the context menu when an option is selected
-                let root = parent_query
-                    .iter_ancestors(trigger.entity())
-                    .last()
-                    .unwrap();
-                commands.entity(root).despawn_recursive();
+                if trigger.button == PointerButton::Primary {
+                    let root = parent_query
+                        .iter_ancestors(trigger.entity())
+                        .last()
+                        .unwrap();
+                    commands.entity(root).despawn_recursive();
 
-                // Run the option callback
-                let callback = &mut query.get_mut(target).unwrap().options[index].f;
-                (callback)(commands.reborrow(), target);
+                    // Run the option callback
+                    let callback = &mut query.get_mut(target).unwrap().options[index].f;
+                    (callback)(commands.reborrow(), target);
+                }
             },
         )
         .id();

--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -93,18 +93,19 @@ pub(crate) fn spawn_option<'a>(
                   mut commands: Commands,
                   parent_query: Query<&Parent>,
                   mut query: Query<&mut ContextMenu>| {
-                // Despawn the context menu when an option is selected
-                if trigger.button == PointerButton::Primary {
-                    let root = parent_query
-                        .iter_ancestors(trigger.entity())
-                        .last()
-                        .unwrap();
-                    commands.entity(root).despawn_recursive();
-
-                    // Run the option callback
-                    let callback = &mut query.get_mut(target).unwrap().options[index].f;
-                    (callback)(commands.reborrow(), target);
+                if trigger.event().button != PointerButton::Primary {
+                    return;
                 }
+                // Despawn the context menu when an option is selected
+                let root = parent_query
+                    .iter_ancestors(trigger.entity())
+                    .last()
+                    .unwrap();
+                commands.entity(root).despawn_recursive();
+
+                // Run the option callback
+                let callback = &mut query.get_mut(target).unwrap().options[index].f;
+                (callback)(commands.reborrow(), target);
             },
         )
         .id();


### PR DESCRIPTION
when opening the context menu, if you were holding down the right click and then hovered over a context menu option, when you'd release the right click it would execute that context menu action, that's been fixed by making the context menu spawn trigger be `Pointer<Up>` instead of `Pointer<Down>`, and also made the context menu options to trigger only on left click (primary button)