### PR TITLE
Migrate bevy to latest main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ rfd = "0.15"
 ron = "0.8.1"
 variadics_please = "1.0"
 
+# This is a temporary workaround for https://github.com/bilelmoussaoui/ashpd/issues/264
+# Should be ok to remove once the issue is fixed, published, and `rfd` points to the new version.
+futures-util = { version = "0.3", features = ["io"] }
+
 # local crates
 
 # bevy_editor_panes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "909b02e9de418fcf3b8960e98c3de423505eadd5", features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "232824c009c38ee26ad308f054bc12888f0020e9", features = [
     "wayland",
 ] }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "909b02e9de418fcf3b8960e98c3de423505eadd5" }
-bevy_macro_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "909b02e9de418fcf3b8960e98c3de423505eadd5" }
-thiserror = "1"
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "232824c009c38ee26ad308f054bc12888f0020e9" }
+bevy_macro_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "232824c009c38ee26ad308f054bc12888f0020e9" }
+thiserror = "2.0"
 serde = { version = "1", features = ["derive"] }
 tracing-test = "0.2.5"
 tracing = "0.1.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "232824c009c38ee26ad308f054bc12888f0020e9", features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", rev = "d6725d3b1baa6a730fa6bfab1bb8f2a9e5f4716e", features = [
     "wayland",
 ] }
-bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "232824c009c38ee26ad308f054bc12888f0020e9" }
-bevy_macro_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "232824c009c38ee26ad308f054bc12888f0020e9" }
+bevy_derive = { git = "https://github.com/bevyengine/bevy.git", rev = "d6725d3b1baa6a730fa6bfab1bb8f2a9e5f4716e" }
+bevy_macro_utils = { git = "https://github.com/bevyengine/bevy.git", rev = "d6725d3b1baa6a730fa6bfab1bb8f2a9e5f4716e" }
 thiserror = "2.0"
 serde = { version = "1", features = ["derive"] }
 tracing-test = "0.2.5"

--- a/bevy_editor_panes/bevy_asset_browser/src/ui/top_bar.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/ui/top_bar.rs
@@ -52,7 +52,7 @@ pub fn refresh_ui(
         // Clear location path UI
         if let Some(childrens) = top_bar_childrens {
             for child in childrens.iter() {
-                commands.entity(*child).despawn();
+                commands.entity(child).despawn();
             }
             commands.entity(top_bar_entity).remove::<Children>();
         }
@@ -169,7 +169,7 @@ fn spawn_path_segment_ui<'a>(
                             .iter()
                             .step_by(2) // Step by 2 to go through each segment, skipping the separators
                             .skip(1) // Skip the "Sources" segment
-                            .position(|child| *child == segment)
+                            .position(|child| child == segment)
                             .expect(
                                 "You shouldn't be able to click on a segment that isn't in the asset location path"
                             );

--- a/bevy_widgets/bevy_i-cant-believe-its-not-bsn/src/hierarchy.rs
+++ b/bevy_widgets/bevy_i-cant-believe-its-not-bsn/src/hierarchy.rs
@@ -256,7 +256,7 @@ mod tests {
         assert_eq!(children.len(), 3);
 
         for (i, child_entity) in children.iter().enumerate() {
-            assert_eq!(world.get::<B>(*child_entity), Some(&B(i as u8)));
+            assert_eq!(world.get::<B>(child_entity), Some(&B(i as u8)));
         }
     }
 
@@ -275,7 +275,7 @@ mod tests {
         assert_eq!(children.len(), 7);
 
         for (i, child_entity) in children.iter().enumerate() {
-            assert_eq!(world.get::<B>(*child_entity), Some(&B(i as u8)));
+            assert_eq!(world.get::<B>(child_entity), Some(&B(i as u8)));
         }
     }
 

--- a/crates/bevy_editor/Cargo.toml
+++ b/crates/bevy_editor/Cargo.toml
@@ -14,6 +14,7 @@ bevy_editor_styles.workspace = true
 serde.workspace = true
 ron.workspace = true
 rfd.workspace = true
+futures-util.workspace = true
 
 # Panes
 bevy_editor_core.workspace = true

--- a/crates/bevy_editor_cam/src/input.rs
+++ b/crates/bevy_editor_cam/src/input.rs
@@ -286,7 +286,8 @@ impl EditorCamInputEvent {
                     PointerAction::Move { delta } => Some(delta),
                     PointerAction::Press { .. }
                     | PointerAction::Cancel
-                    | PointerAction::Release(_) => None,
+                    | PointerAction::Release(_)
+                    | PointerAction::Scroll { .. } => None,
                 })
                 .sum();
 

--- a/crates/bevy_editor_launcher/Cargo.toml
+++ b/crates/bevy_editor_launcher/Cargo.toml
@@ -14,5 +14,6 @@ bevy_footer_bar.workspace = true
 bevy_editor_styles.workspace = true
 
 rfd.workspace = true
+futures-util.workspace = true
 serde.workspace = true
 ron.workspace = true

--- a/crates/bevy_infinite_grid/src/render/mod.rs
+++ b/crates/bevy_infinite_grid/src/render/mod.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use bevy::{
-    asset::load_internal_asset,
+    asset::{load_internal_asset, weak_handle},
     core_pipeline::{core_2d::Transparent2d, core_3d::Transparent3d},
     ecs::{
         query::ROQueryItem,
@@ -37,7 +37,7 @@ use bevy::{
 
 use crate::InfiniteGridSettings;
 
-const GRID_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(15204473893972682982);
+const GRID_SHADER_HANDLE: Handle<Shader> = weak_handle!("7cd38dd1-d707-481e-b38c-0eccb706e629");
 
 pub fn render_app_builder(app: &mut App) {
     load_internal_asset!(app, GRID_SHADER_HANDLE, "grid.wgsl", Shader::from_wgsl);

--- a/crates/bevy_pane_layout/src/handlers.rs
+++ b/crates/bevy_pane_layout/src/handlers.rs
@@ -26,10 +26,7 @@ pub(crate) fn remove_pane(
 
     // Find the index of this pane among its siblings
     let siblings = children_query.get(parent).unwrap();
-    let index = siblings
-        .iter()
-        .position(|entity| *entity == target)
-        .unwrap();
+    let index = siblings.iter().position(|entity| entity == target).unwrap();
 
     let size = size_query.get(target).unwrap().0;
 
@@ -84,10 +81,7 @@ pub(crate) fn split_pane(
 
     // Find the index of this pane among its siblings
     let siblings = children_query.get(parent).unwrap();
-    let index = siblings
-        .iter()
-        .position(|entity| *entity == target)
-        .unwrap();
+    let index = siblings.iter().position(|entity| entity == target).unwrap();
 
     // Parent has a matching divider direction
     let matching_direction = divider_query

--- a/crates/bevy_pane_layout/src/lib.rs
+++ b/crates/bevy_pane_layout/src/lib.rs
@@ -142,8 +142,8 @@ fn cleanup_divider_single_child(
     for (entity, children, parent) in &mut query {
         let mut iter = children
             .iter()
-            .filter(|child| !resize_handle_query.contains(**child));
-        let child = *iter.next().unwrap();
+            .filter(|child| !resize_handle_query.contains(*child));
+        let child = iter.next().unwrap();
         if iter.next().is_some() {
             continue;
         }
@@ -153,7 +153,7 @@ fn cleanup_divider_single_child(
 
         // Find the index of this divider among its siblings
         let siblings = children_query.get(parent.get()).unwrap();
-        let index = siblings.iter().position(|s| *s == entity).unwrap();
+        let index = siblings.iter().position(|s| s == entity).unwrap();
 
         commands
             .entity(parent.get())

--- a/crates/bevy_pane_layout/src/ui.rs
+++ b/crates/bevy_pane_layout/src/ui.rs
@@ -223,10 +223,7 @@ pub(crate) fn spawn_resize_handle<'a>(
 
             let siblings = children_query.get(parent).unwrap();
             // Find the index of this handle among its siblings
-            let index = siblings
-                .iter()
-                .position(|entity| *entity == target)
-                .unwrap();
+            let index = siblings.iter().position(|entity| entity == target).unwrap();
 
             let size_a = size_query.get(siblings[index - 1]).unwrap().0;
             let size_b = size_query.get(siblings[index + 1]).unwrap().0;
@@ -252,10 +249,7 @@ pub(crate) fn spawn_resize_handle<'a>(
             let parent = parent_query.get(target).unwrap().get();
             let siblings = children_query.get(parent).unwrap();
             // Find the index of this handle among its siblings
-            let index = siblings
-                .iter()
-                .position(|entity| *entity == target)
-                .unwrap();
+            let index = siblings.iter().position(|entity| entity == target).unwrap();
 
             let delta = trigger.event().delta;
             let delta = match divider_parent {


### PR DESCRIPTION
- Re-pin bevy to  ~~`232824c009c38ee26ad308f054bc12888f0020e9`~~ `d6725d3b1baa6a730fa6bfab1bb8f2a9e5f4716e`
- Update `thiserror` to `2.0`
- Migrate `Entity`-derefs
- Migrate to `weak_handle!`
- Migrate `ConstructTuple` bundle impl
- Migrate `PointerAction`-matches with new `Scroll`-variant.

> [!CAUTION]
>~~This won't compile because of some issues with the derive macros, yielding errors like:
`use of undeclared crate or module bevy_reflect` or `use of undeclared crate or module bevy_ecs`.~~
> ~~Possibly related to https://github.com/bevyengine/bevy/pull/17330~~
> 
> ~~The errors only seem to happen for `crates/bevy_editor_cam`.~~
>
> Fixed in https://github.com/bevyengine/bevy/commit/fb0e5c484fc254a7fe3cc21a53829b1755c4dae5

- [x] Compiles without errors
- [x] Tests pass
- [x] Editor and launcher runs

Also added temporary a workaround for the Linux [issue](https://github.com/bilelmoussaoui/ashpd/issues/264) regarding `ashpd`.