### PR TITLE
Add support for retaining multiple unrelated scenes on the same entity

### DIFF
--- a/crates/bevy_bsn/src/retain.rs
+++ b/crates/bevy_bsn/src/retain.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use bevy::{
     ecs::component::{ComponentId, ComponentInfo},
     platform_support::{collections::HashMap, hash::FixedHasher},
-    prelude::{Children, Component, Deref, DerefMut, Entity, EntityCommands, EntityWorldMut},
+    prelude::{Component, Deref, DerefMut, Entity, EntityCommands, EntityWorldMut},
 };
 
 use crate::{Scene, *};
@@ -30,11 +30,12 @@ impl<T: Display> From<T> for Key {
 
 /// Receipts allow retaining of scenes that can be intelligently updated.
 #[derive(Default, Component, Clone)]
-pub struct Receipt {
+pub struct Receipt<T = ()> {
     /// The components it inserted.
     components: InsertedComponents,
     /// The anchors of all the children it spawned/retained.
     anchors: HashMap<Anchor, Entity>,
+    marker: core::marker::PhantomData<T>,
 }
 
 /// Map of inserted component ids to a bool of whether they were explicit or required.
@@ -78,14 +79,20 @@ pub trait RetainScene {
     ///  removing components that should be removed, and spawning/updating children.
     ///
     /// Maintains [`Receipt`]s to allow for intelligent updates.
-    fn retain(self, entity: &mut EntityWorldMut) -> Result<(), ConstructError>;
+    fn retain<T: Clone + Default + Send + Sync + 'static>(
+        self,
+        entity: &mut EntityWorldMut,
+    ) -> Result<(), ConstructError>;
 }
 
 impl RetainScene for DynamicScene {
-    fn retain(self, entity: &mut EntityWorldMut) -> Result<(), ConstructError> {
+    fn retain<T: Clone + Default + Send + Sync + 'static>(
+        self,
+        entity: &mut EntityWorldMut,
+    ) -> Result<(), ConstructError> {
         // Clone the receipt for the targeted entity.
         let receipt = entity
-            .get::<Receipt>()
+            .get::<Receipt<T>>()
             .map(ToOwned::to_owned)
             .unwrap_or_default();
 
@@ -122,12 +129,15 @@ impl RetainScene for DynamicScene {
         });
 
         // Retain the children
-        let anchors = self.children.retain_children(entity, receipt.anchors)?;
+        let anchors = self
+            .children
+            .retain_children::<T>(entity, receipt.anchors)?;
 
         // Place the new receipt onto the entity
-        entity.insert(Receipt {
+        entity.insert(Receipt::<T> {
             components,
             anchors,
+            marker: Default::default(),
         });
 
         Ok(())
@@ -139,7 +149,7 @@ pub trait RetainChildren {
     /// Retains the scenes as children of `entity`, updating the [`Receipt`] in the process.
     ///
     /// See: [`RetainScene::retain`].
-    fn retain_children(
+    fn retain_children<T: Clone + Default + Send + Sync + 'static>(
         self,
         entity: &mut EntityWorldMut,
         current_anchors: HashMap<Anchor, Entity>,
@@ -147,38 +157,39 @@ pub trait RetainChildren {
 }
 
 impl RetainChildren for Vec<DynamicScene> {
-    fn retain_children(
+    fn retain_children<T: Clone + Default + Send + Sync + 'static>(
         self,
         entity: &mut EntityWorldMut,
         mut current_anchors: HashMap<Anchor, Entity>,
     ) -> Result<HashMap<Anchor, Entity>, ConstructError> {
-        let children = entity.world_scope(|world| {
+        let mut children = Vec::with_capacity(self.len());
+        let mut children_ids = Vec::with_capacity(self.len());
+
+        entity.world_scope(|world| {
             // Get or create an entity for each fragment.
             let mut i = 0;
-            let children: Vec<_> = self
-                .into_iter()
-                .map(|child| {
-                    // Compute the anchor for this fragment, using it's key if supplied
-                    // or an auto-incrementing counter if not.
-                    let anchor = match child.key() {
-                        Some(name) => Anchor::Keyed(name.clone()),
-                        None => {
-                            let anchor = Anchor::Auto(i);
-                            i += 1;
-                            anchor
-                        }
-                    };
+            for child in self {
+                // Compute the anchor for this fragment, using it's key if supplied
+                // or an auto-incrementing counter if not.
+                let anchor = match child.key() {
+                    Some(name) => Anchor::Keyed(name.clone()),
+                    None => {
+                        let anchor = Anchor::Auto(i);
+                        i += 1;
+                        anchor
+                    }
+                };
 
-                    // Find the existing child entity based on the anchor, or spawn a
-                    // new one.
-                    let entity_id = current_anchors
-                        .remove(&anchor)
-                        .unwrap_or_else(|| world.spawn_empty().id());
+                // Find the existing child entity based on the anchor, or spawn a
+                // new one.
+                let entity_id = current_anchors
+                    .remove(&anchor)
+                    .unwrap_or_else(|| world.spawn_empty().id());
 
-                    // Store the child, it's anchor, and it's entity id.
-                    (child, anchor, entity_id)
-                })
-                .collect();
+                // Store the child, it's anchor, and it's entity id.
+                children.push((child, anchor));
+                children_ids.push(entity_id);
+            }
 
             // Clear any remaining orphans from the previous template. We do this
             // first (before deparenting) so that hooks still see the parent when
@@ -186,14 +197,10 @@ impl RetainChildren for Vec<DynamicScene> {
             for orphan_id in current_anchors.into_values() {
                 world.entity_mut(orphan_id).despawn();
             }
-
-            children
         });
 
-        // Position the entities as children.
-        let child_entities: Vec<_> = children.iter().map(|(_, _, entity)| *entity).collect();
-        entity.remove::<Children>();
-        entity.add_children(&child_entities);
+        // Position the entities as children, not touching any other children.
+        entity.add_children(&children_ids);
 
         // Build the children and produce the receipts. It's important that this
         // happens *after* the entities are positioned as children to make hooks
@@ -201,8 +208,10 @@ impl RetainChildren for Vec<DynamicScene> {
         entity.world_scope(|world| {
             children
                 .into_iter()
-                .map(|(dynamic_scene, anchor, entity_id)| {
-                    dynamic_scene.retain(&mut world.entity_mut(entity_id))?;
+                .enumerate()
+                .map(|(i, (dynamic_scene, anchor))| {
+                    let entity_id = children_ids[i];
+                    dynamic_scene.retain::<T>(&mut world.entity_mut(entity_id))?;
                     Ok((anchor, entity_id))
                 })
                 .collect()
@@ -215,42 +224,66 @@ pub trait RetainSceneExt {
     /// Retains the provided scene on the entity.
     ///
     /// See [`RetainScene::retain`].
-    fn retain_scene(&mut self, scene: impl Scene) -> Result<(), ConstructError>;
+    fn retain_scene(&mut self, scene: impl Scene) -> Result<(), ConstructError> {
+        self.retain_scene_with::<()>(scene)
+    }
+
+    /// Retains the provided scene on the entity with `T` as a marker for the `Receipt`, allowing for multiple retained scenes on the same entity.
+    ///
+    /// See [`RetainScene::retain`].
+    fn retain_scene_with<T: Clone + Default + Send + Sync + 'static>(
+        &mut self,
+        scene: impl Scene,
+    ) -> Result<(), ConstructError>;
 
     /// Retains the provided scenes as children of self.
     ///
     /// See [`RetainChildren::retain_children`].
-    fn retain_child_scenes<T: Scene>(
+    fn retain_child_scenes<S: Scene>(
         &mut self,
-        child_scenes: impl IntoIterator<Item = T>,
+        child_scenes: impl IntoIterator<Item = S>,
+    ) -> Result<(), ConstructError> {
+        self.retain_child_scenes_with::<S, ()>(child_scenes)
+    }
+
+    /// Retains the provided scenes as children of self with `T` as a marker for the `Receipt`, allowing for multiple retained scenes on the same entity.
+    ///
+    /// See [`RetainChildren::retain_children`].
+    fn retain_child_scenes_with<S: Scene, T: Clone + Default + Send + Sync + 'static>(
+        &mut self,
+        child_scenes: impl IntoIterator<Item = S>,
     ) -> Result<(), ConstructError>;
 }
 
 impl RetainSceneExt for EntityWorldMut<'_> {
-    fn retain_scene(&mut self, scene: impl Scene) -> Result<(), ConstructError> {
+    fn retain_scene_with<T: Clone + Default + Send + Sync + 'static>(
+        &mut self,
+        scene: impl Scene,
+    ) -> Result<(), ConstructError> {
         let mut dynamic_scene = DynamicScene::default();
         scene.dynamic_patch(&mut dynamic_scene);
-        dynamic_scene.retain(self)
+        dynamic_scene.retain::<T>(self)
     }
 
-    fn retain_child_scenes<T: Scene>(
+    fn retain_child_scenes_with<S: Scene, T: Clone + Default + Send + Sync + 'static>(
         &mut self,
-        child_scenes: impl IntoIterator<Item = T>,
+        child_scenes: impl IntoIterator<Item = S>,
     ) -> Result<(), ConstructError> {
         // Take the receipt from targeted entity.
-        let receipt = self.take::<Receipt>().unwrap_or_default();
+        let receipt = self.take::<Receipt<T>>().unwrap_or_default();
 
         // Retain the children
         let anchors = child_scenes
             .into_iter()
             .map(DynamicPatch::into_dynamic_scene)
             .collect::<Vec<_>>()
-            .retain_children(self, receipt.anchors)?;
+            .retain_children::<T>(self, receipt.anchors)?;
 
         // Place the receipt back onto the entity
-        self.insert(Receipt {
+        self.insert(Receipt::<T> {
             components: receipt.components,
             anchors,
+            marker: Default::default(),
         });
 
         Ok(())
@@ -262,30 +295,55 @@ pub trait RetainSceneCommandsExt {
     /// Retains the scene on the entity.
     ///
     /// See [`RetainScene::retain`].
-    fn retain_scene(&mut self, scene: impl Scene + Send + 'static);
+    fn retain_scene(&mut self, scene: impl Scene + Send + 'static) {
+        self.retain_scene_with::<()>(scene);
+    }
+
+    /// Retains the provided scene on the entity with `T` as a marker for the `Receipt`, allowing for multiple retained scenes on the same entity.
+    ///
+    /// See [`RetainScene::retain`].
+    fn retain_scene_with<T: Clone + Default + Send + Sync + 'static>(
+        &mut self,
+        scene: impl Scene + Send + 'static,
+    );
 
     /// Retains the provided scenes as children of self.
     ///
     /// See [`RetainChildren::retain_children`].
-    fn retain_child_scenes<T: Scene>(
+    fn retain_child_scenes<S: Scene>(
         &mut self,
-        child_scenes: impl IntoIterator<Item = T> + Send + 'static,
+        child_scenes: impl IntoIterator<Item = S> + Send + 'static,
+    ) {
+        self.retain_child_scenes_with::<S, ()>(child_scenes);
+    }
+
+    /// Retains the provided scenes as children of self.
+    ///
+    /// See [`RetainChildren::retain_children`].
+    fn retain_child_scenes_with<S: Scene, T: Clone + Default + Send + Sync + 'static>(
+        &mut self,
+        child_scenes: impl IntoIterator<Item = S> + Send + 'static,
     );
 }
 
 impl RetainSceneCommandsExt for EntityCommands<'_> {
-    fn retain_scene(&mut self, scene: impl Scene + Send + 'static) {
+    fn retain_scene_with<T: Clone + Default + Send + Sync + 'static>(
+        &mut self,
+        scene: impl Scene + Send + 'static,
+    ) {
         self.queue(|mut entity: EntityWorldMut| {
-            entity.retain_scene(scene).unwrap();
+            entity.retain_scene_with::<T>(scene).unwrap();
         });
     }
 
-    fn retain_child_scenes<T: Scene>(
+    fn retain_child_scenes_with<S: Scene, T: Clone + Default + Send + Sync + 'static>(
         &mut self,
-        child_scenes: impl IntoIterator<Item = T> + Send + 'static,
+        child_scenes: impl IntoIterator<Item = S> + Send + 'static,
     ) {
         self.queue(|mut entity: EntityWorldMut| {
-            entity.retain_child_scenes(child_scenes).unwrap();
+            entity
+                .retain_child_scenes_with::<S, T>(child_scenes)
+                .unwrap();
         });
     }
 }


### PR DESCRIPTION
A small follow-up on https://github.com/bevyengine/bevy_editor_prototypes/pull/181
- Added `EntityWorldMut::retain_scene_with::<T>` and `EntityWorldMut::retain_child_scenes_with::<T>`. `T` is used as a marker to store multiple receipts. This allows retention of different unrelated scenes on an entity.

### Why?
While playing around with widget patterns one idea that popped was to use an immutable component as "props" for a widget/schematic, with hooks to handle the instance lifecycle. Scene retention is a pretty nice way to get functionality similar to Components in libraries like React and Vue.

(⚠️  incomplete pattern below, will keep exploring it)

Let's say we want to crate an `EditorButton` widget with some "props" and a `ButtonState`. We'll create an immutable component with an insert hook to drive the effects that should run to update/render it:
```rust
// This is the driving component for our widget, with its fields being props.
// This is the interface a consumer of this widget would use in a template.
#[derive(Component, Reflect, Default, Clone)]
#[component(immutable, on_insert = editor_button_insert)]
#[require(ButtonState)]
pub struct EditorButton {
    pub disabled: bool,
    pub variant: ButtonVariant,
    pub label: String,
}

// The internal state for our widget
#[derive(Component, Default)]
struct ButtonState {
    hovered: bool,
    pressed: bool,
}

// Insert hook, calling render and retaining the scene.
fn editor_button_insert(mut world: DeferredWorld, context: HookContext) {
    let button = world.get::<EditorButton>(context.entity).unwrap();
    let state = world.get::<ButtonState>(context.entity).unwrap();

    let scene = editor_button_render(context.entity, button, state);

    world
        .commands()
        .entity(context.entity)
        // Note the passed in generic argument. This is what allows us to use `EditorButton` in any retained scene without causing conflicts.
        .retain_scene_with::<EditorButton>(scene);
}

// Render function, looks pretty similar to a functional component in web libraries.
fn editor_button_render(id: Entity, props: &EditorButton, state: &ButtonState) -> impl Scene {
    let (text_color, bg_color) = match props.variant {
        ButtonVariant::Primary => match state.hovered {
            false => (BLUE_50, BLUE_500),
            true => (BLUE_500, BLUE_300),
        },
        // ...
    };

    let label = if state.pressed {
        format!("{} (pressed)", props.label)
    } else {
        props.label.clone()
    };

    bsn! {
        (
            Node {
                flex_direction: FlexDirection::Row,
            },
            Button,
            BackgroundColor(bg_color),
        ) [
            (
                Text(label),
                TextColor(text_color)
            ),

            // A very verbose way to handle hover state... needs better pattern/abstraction
            On(move |_: Trigger<Pointer<Over>>, mut states: Query<&mut ButtonState>, mut commands: Commands| {
                // Update state
                states.get_mut(id).unwrap().hovered = true;

                // Re-insert to trigger effect
                commands.entity(id).queue(|mut entity: EntityWorldMut| {
                    let b = entity.take::<EditorButton>().unwrap();
                    entity.insert(b);
                });
            }),

            // Out
            // ...

            // Pressed
            // ...

            // Released
            // ...
        ]
    }
}
```

This widget can then be used in any template like so:
```rust
bsn! {
    Node {
        position_type: PositionType::Absolute,
        // ...
    } [
        EditorButton {
            label: "Click me!"
        } [
            On(|_: Trigger<Pointer<Click>>| {
                info!("Clicked!");
            })
        ],
    ]
};
```

The nice thing about this pattern is that it is decoupled from the reactivity solution it uses. It could use `retain_scene`, or it could just spawn a scene and use systems/observers to update it, or it could use a future true reactive solution. But it doesn't matter to the consumer!