### PR TITLE
Refine milestones and add a section on architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Bevy Editor Prototypes
 
 > [!WARNING]
-> This project is a prototype for a shippable Bevy Editor and is still in heavy development and testing. 
+> This project is a prototype for a shippable Bevy Editor and is still in heavy development and testing.
 > Everything you see is very much a work-in-progress. Read about what we're building in the [Design Book](https://bevyengine.github.io/bevy_editor_prototypes/)! or [Figma document].
 > To run just type the ```cargo run``` or ```cargo run --example``` command in the terminal of the `bevy_editor_prototypes` folder.
+
+Want to see what we have planned? Check out [design-book/vision] for a high-level view on our goals, and [design-book/architecture] for a summary of how we think it should all fit together.
+
+Want to help? See [design-book/roadmap] for an up-to-date summary of the work that has been done and needs to be done to advance the project to the next phase.
+To avoid ballooning scope and ensure we can ship something useful and reasonably polished, please try your best to focus efforts on the next milestone that has yet to be completed, or standalone proof-of-concepts or design work for important open questions.
 
 ## Figma Designs
 

--- a/design-book/src/SUMMARY.md
+++ b/design-book/src/SUMMARY.md
@@ -3,6 +3,7 @@
 - [Vision](./vision.md)
 - [Roadmap](./roadmap.md)
 - [Glossary](./glossary.md)
+- [Architecture](./architecture.md)
 - [Design Constraints](./design-constraints.md)
 - [Human Interface Guidelines](./human-interface-guidelines.md)
   - [Design Paradigms](./design-paradigms.md)

--- a/design-book/src/architecture.md
+++ b/design-book/src/architecture.md
@@ -4,7 +4,8 @@ Bevy's editor, like the rest of Bevy, is fundamentally designed to be modular, r
 But at the same time, a new user's initial experience should be polished, reasonably complete and ready to jump into.
 
 These goals are obviously in tension, and to thread the needle we need to think carefully about our project architecture, both organizationally and technically.
-The agreed-upon architecture is summarized below, with future extensions and critical open questions listed below.
+
+So far, we've agreed upon the following architecture:
 
 - the Bevy editor is a binary application made using `bevy`, and `bevy_ui`
 - the Bevy editor will live in the main Bevy repo, and must be updated and fixed as part of the ordinary development process
@@ -20,18 +21,22 @@ The agreed-upon architecture is summarized below, with future extensions and cri
   - UI widgets, an undo-redo model, preferences, viewport widgets, a node graph abstraction and more all great candidates for this approach
 - self-contained GUI-based development tools should be self-contained `Plugin`s which can be reused by projects without requiring the Bevy editor binary
   - for example: an asset browser, entity inspector or system visualization tools
+- the editor will not try and inspect the running process: instead, users will be encouraged to reuse modular dev tools from the editor, `bevy_dev_tools` and the broader ecosystem by compiling them into their own project under a per-project `dev_tools` feature flag
+  - we should still develop, ship and promote powerful, polished tools for these use cases!
+  - this is significantly simpler and offers more flexibility to users around customized workflows
 
   ## Open questions
 
+These questions are pressing, and need serious design work.
+
 - how do we distribute the Bevy editor?
   - do users need to have a local working copy of the Rust compiler to use the editor effectively?
-- how does the Bevy editor communicate with the Bevy game?
-  - during scene editing?
-  - while the game is running?
-- should the Bevy Editor be able to inspect users games, or should the users simply add modular dev tools to their own project?
-  - we can always add a "run project" button that calls `cargo run`, but do we want to be fancier than that?
+- how does the Bevy editor communicate with the Bevy game to enable effective scene editing with user-defined types?
+- how should undo-redo be handled?
 
 ## Extensions
+
+These questions are less pressing, but deserve investigation to ensure we can support more advanced user needs.
 
 - do we need a launcher?
   - are users able to use versions of the Bevy editor that are newer (or older) than their current project?
@@ -41,3 +46,4 @@ The agreed-upon architecture is summarized below, with future extensions and cri
   - where are they stored?
   - how are they shared between projects?
   - how are they shared between team members?
+- can the Bevy editor play nicely with a hotpatched type definitions for things like components?

--- a/design-book/src/architecture.md
+++ b/design-book/src/architecture.md
@@ -1,0 +1,43 @@
+# Architecture
+
+Bevy's editor, like the rest of Bevy, is fundamentally designed to be modular, reusable, and robust to weird use patterns.
+But at the same time, a new user's initial experience should be polished, reasonably complete and ready to jump into.
+
+These goals are obviously in tension, and to thread the needle we need to think carefully about our project architecture, both organizationally and technically.
+The agreed-upon architecture is summarized below, with future extensions and critical open questions listed below.
+
+- the Bevy editor is a binary application made using `bevy`, and `bevy_ui`
+- the Bevy editor will live in the main Bevy repo, and must be updated and fixed as part of the ordinary development process
+  - as a large binary project, it represents a great proving ground for how changes will impact users
+  - as an important part of Bevy users' workflow, it's important that we don't break it!
+  - as a consequence, the Bevy editor cannot rely on any crates that themselves rely on `bevy`: they are not kept up to date with `main`
+  - fixing the editor before each release is much more difficult, requiring diverse expertise and a large volume of changes all at once
+  - note: until we have an MVP: the editor work is done outside of the main repo, and tracks `main` on an as-updated basis
+- functionality that is useful without a graphical editor should be usable without the editor
+  - project creation functionality should live in the `bevy_cli`, and be called by the editor
+  - asset preprocessing steps should be standalone tools whenever possible, which can then be called by the `bevy_cli` (and then the editor)
+- the foundational, reusable elements of the `bevy_editor` should be spun out into their own crates once they mature, but are best prototyped inside of the code for the specific binary application
+  - UI widgets, an undo-redo model, preferences, viewport widgets, a node graph abstraction and more all great candidates for this approach
+- self-contained GUI-based development tools should be self-contained `Plugin`s which can be reused by projects without requiring the Bevy editor binary
+  - for example: an asset browser, entity inspector or system visualization tools
+
+  ## Open questions
+
+- how do we distribute the Bevy editor?
+  - do users need to have a local working copy of the Rust compiler to use the editor effectively?
+- how does the Bevy editor communicate with the Bevy game?
+  - during scene editing?
+  - while the game is running?
+- should the Bevy Editor be able to inspect users games, or should the users simply add modular dev tools to their own project?
+  - we can always add a "run project" button that calls `cargo run`, but do we want to be fancier than that?
+
+## Extensions
+
+- do we need a launcher?
+  - are users able to use versions of the Bevy editor that are newer (or older) than their current project?
+- how do we allow users to add and remove non-trivial functionality to the editor?
+  - for now they can just fork things,
+- how are preferences handled?
+  - where are they stored?
+  - how are they shared between projects?
+  - how are they shared between team members?

--- a/design-book/src/roadmap.md
+++ b/design-book/src/roadmap.md
@@ -60,6 +60,8 @@ It's best not to plan too far in advance!
 
 ## Stage 3: Editor-Game Interaction
 
+- [ ] create a design document laying out the possible architectures for editor <-> game communication and the tradeoffs
+- [ ] select an architecture to use for now
 - [ ] provide the editor with access to the game's code, allowing it to correctly initialize objects
   - [ ] game-specific rendering techniques display correctly in the editor's scene editing
 - [ ] users can press a button in the editor, launching the game from the very beginning
@@ -121,7 +123,6 @@ It's best not to plan too far in advance!
   - [ ] launch a prebuilt binary (for non-technical users)
   - [ ] cargo workspace apps and examples (for developers using the editor from the codebase)
     - [ ] set feature flags
-    - [ ] (stretch goal. maybe as part of a possible vscode integration) read/write `.vscode/launch.json`
   - [ ] option to launch with a default profile when the editor opens
 
 ## Uncategorized work
@@ -148,9 +149,10 @@ They haven't been forgotten, and are listed in no particular order here:
 - [ ] basic audio editing
 - [ ] graph visualization of component values
 - [ ] entity clustering with a memory usage breakdown
-- [ ] generated in-editor documentation for Component/Resource types
+- [ ] generated in-editor documentation for Component/Resource/Event types
 - [ ] go to definition support that opens the relevant code in your IDE of choice
 - [ ] event diagnostics
+- [ ] centralized design methodology ala [A4 design](https://developer.blender.org/docs/handbook/design/a4_design/)
 
-While there are also important engine features that will unblock or improve various parts of the editor (relations! BSN!),
+While there are also important engine features that will unblock or improve various parts of the editor (BSN!),
 this should not be tracked here: the emphasis is on user-facing goals, not any particular path.

--- a/design-book/src/roadmap.md
+++ b/design-book/src/roadmap.md
@@ -13,11 +13,12 @@ For actionable, well-scoped items, please open issues instead.
 As you complete tasks, check them off here!
 The tasks don't need to be done *well* to be considered completed here: the Bevy community is very good at cleaning up loose strings as we work.
 
-Feel free to tackle any listed item in any order: foundations and primitives can often be built out well before the features that need them are in place.
 This list is not "all of the features that the editor will have": other stages will follow as these features are added.
 It's best not to plan too far in advance!
 
 ## Stage 0: Hello Project
+
+After this milestone, we have a project that Bevy developers can work on together.
 
 - [x] make a repo
 - [x] add a README
@@ -27,70 +28,97 @@ It's best not to plan too far in advance!
 - [x] define basic constraints for how we're building the editor
 - [x] define a shared vision for what the editor is (and is not)
 
-## Stage 1: Standalone Read-Only Editor
+## Stage 1: Read-only Scene Viewer
+
+After this milestone, we have a useful if limited tool that lets users see how scenes would be rendered and represented in Bevy.
+
+If this work is done to a high level of polish, we can consider providing it as clearly scoped standalone tool for Bevy users to experiment with and refine.
 
 - [x] can load scenes from disk using a native file picking widget
 - [x] can display scenes in a viewer
   - [x] 2D
   - [x] 3D
+- [x] infinite grid
+  - [x] 2D
+  - [x] 3D
 - [x] simple camera controller
   - [x] 2D
   - [x] 3D
-- [ ] gizmos can be toggled
+- [ ] toggleable gizmos for physical entities that aren't visible in the scene itself
   - [ ] UI outlines
   - [ ] lights
   - [ ] AABBs
+  - [ ] cameras
 - [x] lists entities in the scene
   - [ ] supports hierarchy via a folding tree view
-- [x] click entities in the list to select them.
+- [ ] select entities
+  - [ ] look up entities by name
+  - [ ] from the scene using picking
+  - [x] from the inspector
+  - [ ] show selected entities in the inspector
+  - [ ] clearly show selected entities in the world via an outline
+  - [ ] one entity
+  - [ ] multiple entities
 - [ ] components of selected entity are shown in the inspector with component values, including components specific to the user's game
 - [ ] resources can be inspected, showing their values
 - [ ] loaded assets can be inspected, providing basic information about them
 
 ## Stage 2: Basic Editing Capabilities
 
-- [ ] undo-redo abstraction
-- [ ] entities can be added and removed
-- [ ] components and resources can be added, removed, and modified
+After this milestone, the scene viewer can be used to make very simple changes to scenes, allowing it to be used as a simple level editor tool.
+
+Additionally, the inspector can and should be spun out and shipped as a helpful first-party dev tool.
+
+- [ ] entities can be spawned
+- [ ] components can be added or removed from entities
+- [ ] resources can be added or removed
+- [ ] the values of components and resources can be modified
+- [ ] interactive transform gizmo in the viewport that modifies all selected objects
 - [ ] scenes can be saved back to disk
-- [ ] interactive transform gizmo in the viewport
-  - [ ] translation
-  - [ ] scale
-  - [ ] rotation
+  - .bsn integration would be ideal, but we can read and write .ron scene files well enough to make an MVP
 
-## Stage 3: Editor-Game Interaction
+## Stage 3: Technical Difficulties
 
-- [ ] create a design document laying out the possible architectures for editor <-> game communication and the tradeoffs
-- [ ] select an architecture to use for now
-- [ ] provide the editor with access to the game's code, allowing it to correctly initialize objects
-  - [ ] game-specific rendering techniques display correctly in the editor's scene editing
-- [ ] users can press a button in the editor, launching the game from the very beginning
-- [ ] users can press a button in the editor, and their game will run, loading the currently active scene
-- [ ] asset hotreloading, allowing changes in the asset file to be reflected in the editor and game views
-- [ ] components that reference assets can be changed to load a new asset via a file dialog
-- [ ] entity hierarchies can be spawned and despawned via a GUI
-  - [ ] manually
-  - [ ] by composing scene files
-- [ ] distinct editor and game views that can be run simultaneously
-- [ ] live edit resource and component data in the editor view while the game is running
+After this milestone, we've solved the most critical technical challenges that may force large-scale refactors and rewrites,
+and have the confidence to build more features without accumulating serious technical risk.
 
-## Stage 4: UI/UX Foundations
-
+- [ ] undo-redo abstraction
+  - [ ] architecture established
+  - [ ] used for all modifications
+- [ ] Bevy Editor can call the bevy_cli
+- [ ] game-defined components can be edited and instantiated
+- [ ] game-specific rendering techniques display correctly in the editor's scene editing
+- [ ] a stand-alone Bevy editor executable or launcher can be shipped as a download
+- [ ] asset hot reloading works inside of the editor, changing assets displayed when the underlying file is modified
+- [ ] Bevy Editor users can press "Run Game", and an appropriate binary for the game will be run in a new window
 - [ ] tooltips
 - [ ] hotkeys
-- [ ] primitive widgets
+  - [ ] standardized framework to add these
+  - [ ] centralized list for users to view the hotkeys
+  - [ ] hotkeys for our actions
+- [ ] keyboard-based UI navigation
+
+## Stage 4: Design Time
+
+After this milestone, we will have the raw components needed to quickly build out new UI-based features in a consistent, polished fashion.
+
+Additionally, these widgets will be useful for Bevy's examples, users and other dev tooling.
+
+- [ ] mockup demonstrating what an ideal out-of-the-box 1.0 editor would look like
+- [ ] clear written and visual guidelines for exactly what the "default Bevy editor theme" looks like and cares about
+- [ ] Bevy Editor themed widgets (built on top of headless widgets)
   - [ ] text entry
   - [ ] numeric entry
+  - [ ] file path entry
   - [ ] radio buttons
   - [ ] dropdown
   - [ ] checkboxes
   - [ ] slider
   - [ ] color selector
   - [ ] image preview
-  - [ ] file path entry
   - [ ] progress bar
   - [ ] audio playback widget
-- [ ] editor UI foundations
+- [ ] editor-specific widgets
   - [ ] resizable panes
   - [ ] scrollable tool detail panels
   - [ ] toolbar
@@ -98,38 +126,49 @@ It's best not to plan too far in advance!
   - [ ] context menus
   - [ ] command palette
   - [ ] toggleable fullscreen panes
-- [ ] dedicated hotkeys and controls for the most common operations:
-  - [ ] manipulating camera
-  - [ ] modifying transforms
-  - [ ] toggling visibility
-  - [ ] adding and removing entities
-  - [ ] saving the project
-  - [ ] opening the command palette
+- [ ] exclusively use these widgets in the editor itself
 
-## Stage 5: Fundamental Features
+## Stage 5: End-to-end projects
 
-- [ ] preferences
-  - [ ] hotkey rebinding
-  - [ ] camera controls
-  - [ ] preferred language
-- [ ] scene object picking: click on objects in the scene to select them in the inspector
-- [ ] entities can be looked up by name in the inspector
-- [ ] system stepping support
-- [ ] create new Bevy project
-  - [ ] blank
+After this milestone, users will be able to download the Bevy editor and use it to get started with Bevy.
+
+The completion of this milestone represents the first true MVP of a "Bevy editor", and the point where we should consider shipping this as an experimental alpha editor to experienced Bevy users,
+and moving it to live inside of the `bevyengine/bevy` repository.
+
+- [ ] download the Bevy editor as a standalone executable
+- [ ] create a new Bevy project
+  - [ ] minimal / blank
   - [ ] from template
-- [ ] localization framework (first-party: English-only)
+  - [ ] basic browsing for templates
+- [ ] browse and open existing Bevy projects
 - [ ] launch targets/profiles
   - [ ] launch a prebuilt binary (for non-technical users)
   - [ ] cargo workspace apps and examples (for developers using the editor from the codebase)
     - [ ] set feature flags
   - [ ] option to launch with a default profile when the editor opens
 
+### Stage 6: Customization is Accessibility
+
+After this milestone, users will be able to customize the editor in simple ways to make it meet their needs.
+
+- [ ] preferences
+  - [ ] hotkey rebinding
+  - [ ] camera controls
+  - [ ] preferred language
+  - [ ] hidden and visible widgets
+- [ ] pane layout persists across editor invocations
+- [ ] themeable UI
+  - [ ] light mode / dark mode
+- [ ] localization framework (first-party: English-only)
+
 ## Uncategorized work
 
 There's a great deal of further feature work that needs to be done beyond the current milestones.
 They haven't been forgotten, and are listed in no particular order here:
 
+- [ ] theming, especially light-mode
+- [ ] system stepping support
+- [ ] experimental code hotpatching works inside of the editor
 - [ ] editor extensions, for adding custom functionality
 - [ ] a central hub for hosting (and selling?) editor extensions and assets
 - [ ] performance overlays of all kinds
@@ -154,5 +193,5 @@ They haven't been forgotten, and are listed in no particular order here:
 - [ ] event diagnostics
 - [ ] centralized design methodology ala [A4 design](https://developer.blender.org/docs/handbook/design/a4_design/)
 
-While there are also important engine features that will unblock or improve various parts of the editor (BSN!),
+While there are also important engine features that will unblock or improve various parts of the editor (BSN! better screen reader integration!),
 this should not be tracked here: the emphasis is on user-facing goals, not any particular path.


### PR DESCRIPTION
This PR is a cleanup and clarification pass, aimed at helping unblock project management and refocus developers here on achieving an MVP, rather than waiting on upstream features.

The main elements:

1. Add a mention of the design book to the README, in the hopes that people will immediately jump into that as a starting point.
2. Add an architecture.md section, which helps summarize the big project architecture questions that we've decided on, and lists out the open questions we still need research on.
3. Refines the milestones, shuffling work items around and focusing on the deliverable outcomes after each step.

If there's an information that's out of date, please correct me! If you disagree with my prioritization or architectural choices, now is the time to hash it out :)