### PR TITLE
Fix Clone impl of bevy_proto_bsn's ReflectedValue

### DIFF
--- a/crates/bevy_proto_bsn/src/bsn_reflect.rs
+++ b/crates/bevy_proto_bsn/src/bsn_reflect.rs
@@ -207,11 +207,7 @@ impl Clone for ReflectedValue {
     fn clone(&self) -> Self {
         Self {
             type_id: self.type_id,
-            instance: self
-                .instance
-                .as_ref()
-                .reflect_clone()
-                .expect("Failed to clone instance"),
+            instance: self.instance.as_ref().to_dynamic(),
         }
     }
 }


### PR DESCRIPTION
Took bevy_proto_bsn to use and had trouble deserializing assets.

As far as I can tell, `PartialReflect::reflect_clone` always returns NotImplemented. Changed the `reflect_clone` call to `to_dynamic` and things seem to work. I had to make a similar change when updating our Blenvy version to support Bevy 0.16 after being on 0.15.