### PR TITLE
State preserving template building

### DIFF
--- a/bevy_widgets/bevy_i-cant-believe-its-not-bsn/src/template.rs
+++ b/bevy_widgets/bevy_i-cant-believe-its-not-bsn/src/template.rs
@@ -222,7 +222,6 @@ fn build_template_base(
         .into_iter()
         .map(|(fragment, anchor, entity, new)| {
             if preserving {
-                println!("HERE");
                 fragment.build_preserving(entity, world, !new);
             } else {
                 fragment.build(entity, world);

--- a/bevy_widgets/bevy_i-cant-believe-its-not-bsn/src/template.rs
+++ b/bevy_widgets/bevy_i-cant-believe-its-not-bsn/src/template.rs
@@ -70,7 +70,7 @@ impl Fragment {
     /// It does not modify components of children that already exist, only initializes newly
     /// created ones.
     ///
-    /// If build_entity is false it does not build the given entity, only its children.
+    /// If `build_entity` is false it does not build the given entity, only its children.
     ///
     /// It may modify the entity itself and some or all of its children.
     /// A [`Receipt`] is stored on the entity to track what was built, enabling incremental updates.
@@ -423,7 +423,7 @@ pub trait TemplateEntityCommandsExt {
     /// not modify components of children that already exist, only initializes newly
     /// created ones.
     ///
-    /// If build_entity is false it does not build the entity, only its children.
+    /// If `build_entity` is false it does not build the entity, only its children.
     fn build_nonexistent<F>(&mut self, fragment: F, build_entity: bool) -> &mut Self
     where
         F: TryInto<Fragment>;


### PR DESCRIPTION
## Summary

This change introduces a new approach to template building where components of entities that already exist (based on their anchor) are preserved, unless they are not part of the template in which case they will be despawned.

This functionality can be accessed by calling `build_preserving` or `build_children_preserving` on `EntityCommands`.

I also added a few tests to verify this behavior.

## Why?

Currently, when building templates, the entire component set of an entity is overwritten by the template, regardless of whether the entity already exists. This behavior is problematic for UI elements that rely on persistent state, as it resets the state of child components.

## Example

Consider a scenario with expansion tiles (foldable UI elements) in the scene tree. If some tiles are folded and an entity is deleted, the scene tree will need to be rebuilt. With the current approach, rebuilding the scene results in the template overwriting the state of the expansion tiles, causing them to unfold and effectively discarding the user's prior state.