### PR TITLE
Fix 3d viewport picking passthrough and camera input

### DIFF
--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -82,7 +82,7 @@ impl Plugin for Viewport3dPanePlugin {
 struct Active;
 
 // FIXME: This system makes a lot of assumptions and is therefore rather fragile. Does not handle multiple windows.
-/// Sends copies of [`PointerAction`]s from the window pointer to pointers belonging to the viewport panes.
+/// Sends copies of [`PointerInput`] event actions from the mouse pointer to pointers belonging to the viewport panes.
 fn render_target_picking_passthrough(
     viewports: Query<(Entity, &Bevy3dViewport)>,
     content: Query<&PaneContentNode>,

--- a/crates/bevy_editor/src/lib.rs
+++ b/crates/bevy_editor/src/lib.rs
@@ -58,7 +58,13 @@ impl Plugin for EditorPlugin {
                 ui::EditorUIPlugin,
                 AssetBrowserPanePlugin,
                 LoadGltfPlugin,
+                MeshPickingPlugin,
             ))
+            .insert_resource(MeshPickingSettings {
+                // Workaround for the Mesh2d circle blocking picking in the 3d viewport (even though it is not visible).
+                require_markers: true,
+                ..default()
+            })
             .add_systems(Startup, dummy_setup);
     }
 }
@@ -106,6 +112,7 @@ fn dummy_setup(
         Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(1.5)))),
         MeshMaterial3d(materials_3d.add(Color::WHITE)),
         Name::new("Plane"),
+        Pickable::default(),
     ));
 
     commands.spawn((


### PR DESCRIPTION
Picking for objects through the viewport will now behave properly, including the camera controller.
It only took 8 months! <sub> well, just one day..<sub> today.

## Solution
- Assign each 3d viewport panel/camera their own custom pointer entity
- Copy every `PointerInput` event action from the mouse to these custom pointers with their location adjusted
- Rework camera input to respond to input from custom pointers