### PR TITLE
Improve selection

### DIFF
--- a/bevy_editor_panes/bevy_3d_viewport/src/selection_box.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/selection_box.rs
@@ -1,6 +1,6 @@
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
-use bevy_editor_core::SelectedEntity;
+use bevy_editor_core::selection::SelectedEntity;
 use bevy_render::primitives::Aabb;
 
 #[derive(SystemParam)]

--- a/bevy_editor_panes/bevy_properties_pane/src/lib.rs
+++ b/bevy_editor_panes/bevy_properties_pane/src/lib.rs
@@ -3,7 +3,7 @@
 //! Data can be viewed and modified in real-time, with changes being reflected in the application.
 
 use bevy::{color::palettes::tailwind, prelude::*, reflect::*};
-use bevy_editor_core::SelectedEntity;
+use bevy_editor_core::selection::SelectedEntity;
 use bevy_i_cant_believe_its_not_bsn::{Template, TemplateEntityCommandsExt, template};
 use bevy_pane_layout::prelude::{PaneAppExt, PaneStructure};
 

--- a/bevy_editor_panes/bevy_scene_tree/src/lib.rs
+++ b/bevy_editor_panes/bevy_scene_tree/src/lib.rs
@@ -1,7 +1,9 @@
 //! An interactive, collapsible tree view for hierarchical ECS data in Bevy.
 
 use bevy::{app::Plugin, color::palettes::tailwind, prelude::*};
-use bevy_editor_core::SelectedEntity;
+use bevy_editor_core::selection::{
+    SelectedEntity, common_handlers::toggle_select_on_click_for_entity,
+};
 use bevy_i_cant_believe_its_not_bsn::{Template, TemplateEntityCommandsExt, on, template};
 use bevy_pane_layout::prelude::{PaneAppExt, PaneStructure};
 
@@ -62,16 +64,6 @@ fn scene_tree_row_for_entity(
     name: &Name,
     selected_entity: &SelectedEntity,
 ) -> Template {
-    let set_selected_entity_on_click =
-        move |mut trigger: On<Pointer<Click>>, mut selected_entity: ResMut<SelectedEntity>| {
-            if selected_entity.0 == Some(entity) {
-                selected_entity.0 = None;
-            } else {
-                selected_entity.0 = Some(entity);
-            }
-            trigger.propagate(false);
-        };
-
     template! {
         {entity}: (
             Node {
@@ -82,7 +74,7 @@ fn scene_tree_row_for_entity(
             BorderRadius::all(Val::Px(4.0)),
             BackgroundColor(if selected_entity.0 == Some(entity) { tailwind::NEUTRAL_700.into() } else { Color::NONE }),
         ) => [
-            on(set_selected_entity_on_click);
+            on(toggle_select_on_click_for_entity(entity));
             (
                 Text(name.into()),
                 TextFont::from_font_size(11.0),

--- a/crates/bevy_editor/src/lib.rs
+++ b/crates/bevy_editor/src/lib.rs
@@ -18,6 +18,7 @@ pub use bevy;
 
 use bevy_context_menu::ContextMenuPlugin;
 use bevy_editor_core::EditorCorePlugin;
+use bevy_editor_core::selection::common_handlers::toggle_select_on_click;
 use bevy_editor_styles::StylesPlugin;
 
 // Panes
@@ -108,12 +109,14 @@ fn dummy_setup(
         Name::new("Circle"),
     ));
 
-    commands.spawn((
-        Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(1.5)))),
-        MeshMaterial3d(materials_3d.add(Color::WHITE)),
-        Name::new("Plane"),
-        Pickable::default(),
-    ));
+    commands
+        .spawn((
+            Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(1.5)))),
+            MeshMaterial3d(materials_3d.add(Color::WHITE)),
+            Name::new("Plane"),
+            Pickable::default(),
+        ))
+        .observe(toggle_select_on_click);
 
     commands.spawn((
         DirectionalLight {

--- a/crates/bevy_editor_core/src/lib.rs
+++ b/crates/bevy_editor_core/src/lib.rs
@@ -1,31 +1,18 @@
 //! This crate provides core functionality for the Bevy Engine Editor.
 
-use bevy::{ecs::entity::Entities, prelude::*};
+pub mod selection;
+pub mod utils;
 
-/// Plugin for the editor scene tree pane.
+use bevy::prelude::*;
+
+use crate::{selection::SelectionPlugin, utils::CoreUtilsPlugin};
+
+/// Core plugin for the editor.
+#[derive(Default)]
 pub struct EditorCorePlugin;
 
 impl Plugin for EditorCorePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<SelectedEntity>()
-            .register_type::<SelectedEntity>()
-            .add_systems(PostUpdate, reset_selected_entity_if_entity_despawned);
-    }
-}
-
-/// The currently selected entity in the scene.
-#[derive(Resource, Default, Reflect)]
-#[reflect(Resource, Default)]
-pub struct SelectedEntity(pub Option<Entity>);
-
-/// System to reset [`SelectedEntity`] when the entity is despawned.
-pub fn reset_selected_entity_if_entity_despawned(
-    mut selected_entity: ResMut<SelectedEntity>,
-    entities: &Entities,
-) {
-    if let Some(e) = selected_entity.0 {
-        if !entities.contains(e) {
-            selected_entity.0 = None;
-        }
+        app.add_plugins((SelectionPlugin, CoreUtilsPlugin));
     }
 }

--- a/crates/bevy_editor_core/src/selection.rs
+++ b/crates/bevy_editor_core/src/selection.rs
@@ -1,0 +1,86 @@
+//! Editor selection module.
+
+use bevy::{ecs::entity::Entities, prelude::*};
+
+/// Editor selection plugin.
+#[derive(Default)]
+pub struct SelectionPlugin;
+
+impl Plugin for SelectionPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<SelectedEntity>()
+            .register_type::<SelectedEntity>()
+            .add_systems(PostUpdate, reset_selected_entity_if_entity_despawned);
+    }
+}
+
+/// The currently selected entity in the scene.
+#[derive(Resource, Default, Reflect)]
+#[reflect(Resource, Default)]
+pub struct SelectedEntity(pub Option<Entity>);
+
+impl SelectedEntity {
+    /// Toggle selection for an entity.
+    pub fn toggle(&mut self, entity: Entity) {
+        debug_assert_ne!(entity, Entity::PLACEHOLDER);
+        if self.0 == Some(entity) {
+            self.0 = None;
+        } else {
+            self.0 = Some(entity);
+        }
+    }
+
+    /// Set an entity as selected.
+    pub fn set(&mut self, entity: Entity) {
+        debug_assert_ne!(entity, Entity::PLACEHOLDER);
+        self.0 = Some(entity);
+    }
+
+    /// Empty the selection.
+    pub fn reset(&mut self) {
+        self.0 = None;
+    }
+}
+
+/// System to removes entity [`SelectedEntity`] when the entity is despawned.
+pub fn reset_selected_entity_if_entity_despawned(
+    mut selected_entity: ResMut<SelectedEntity>,
+    entities: &Entities,
+) {
+    if let Some(e) = selected_entity.0 {
+        if !entities.contains(e) {
+            selected_entity.reset();
+        }
+    }
+}
+
+/// Common handler observer systems for entity selection behavior.
+pub mod common_handlers {
+    use crate::utils::DragCancelClick;
+
+    use super::*;
+
+    /// Toggles selection for this entity when it is clicked.
+    pub fn toggle_select_on_click(
+        mut trigger: On<Pointer<DragCancelClick>>,
+        mut selected_entity: ResMut<SelectedEntity>,
+    ) {
+        if trigger.button == PointerButton::Primary {
+            selected_entity.toggle(trigger.target());
+            trigger.propagate(false);
+        }
+    }
+
+    /// Toggles selection for an entity when this entity is clicked.
+    pub fn toggle_select_on_click_for_entity(
+        entity: Entity,
+    ) -> impl FnMut(On<Pointer<DragCancelClick>>, ResMut<SelectedEntity>) {
+        move |mut trigger: On<Pointer<DragCancelClick>>,
+              mut selected_entity: ResMut<SelectedEntity>| {
+            if trigger.button == PointerButton::Primary {
+                selected_entity.toggle(entity);
+                trigger.propagate(false);
+            }
+        }
+    }
+}

--- a/crates/bevy_editor_core/src/selection.rs
+++ b/crates/bevy_editor_core/src/selection.rs
@@ -42,7 +42,7 @@ impl SelectedEntity {
     }
 }
 
-/// System to removes entity [`SelectedEntity`] when the entity is despawned.
+/// System to reset [`SelectedEntity`] when the entity is despawned.
 pub fn reset_selected_entity_if_entity_despawned(
     mut selected_entity: ResMut<SelectedEntity>,
     entities: &Entities,

--- a/crates/bevy_editor_core/src/utils.rs
+++ b/crates/bevy_editor_core/src/utils.rs
@@ -1,0 +1,67 @@
+//! Editor core utils.
+
+use std::time::Duration;
+
+use bevy::{
+    picking::backend::HitData, platform::collections::HashMap, platform::time::Instant, prelude::*,
+};
+
+/// Editor core utils plugin.
+#[derive(Default)]
+pub struct CoreUtilsPlugin;
+
+impl Plugin for CoreUtilsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DragCancelClickState>()
+            .add_event::<Pointer<DragCancelClick>>()
+            .register_type::<Pointer<DragCancelClick>>()
+            .add_observer(on_press)
+            .add_observer(on_drag_start)
+            .add_observer(on_release);
+    }
+}
+
+fn on_press(trigger: On<Pointer<Press>>, mut state: ResMut<DragCancelClickState>) {
+    state.0.insert(trigger.target(), Instant::now());
+}
+
+fn on_drag_start(trigger: On<Pointer<DragStart>>, mut state: ResMut<DragCancelClickState>) {
+    state.0.remove(&trigger.target());
+}
+
+fn on_release(
+    trigger: On<Pointer<Release>>,
+    mut state: ResMut<DragCancelClickState>,
+    mut commands: Commands,
+) {
+    let now = Instant::now();
+    if let Some(instant) = state.remove(&trigger.target()) {
+        let event = Pointer::new(
+            trigger.pointer_id,
+            trigger.pointer_location.clone(),
+            DragCancelClick {
+                button: trigger.button,
+                hit: trigger.hit.clone(),
+                duration: now - instant,
+            },
+        );
+        commands.trigger_targets(event.clone(), trigger.target());
+        commands.send_event(event);
+    }
+}
+
+/// Fires when a pointer sends a pointer pressed event followed by a pointer released event, with the same
+/// `target` entity for both events and without a drag start event in between.
+#[derive(Clone, PartialEq, Debug, Reflect)]
+#[reflect(Clone, PartialEq)]
+pub struct DragCancelClick {
+    /// Pointer button pressed and lifted to trigger this event.
+    pub button: PointerButton,
+    /// Information about the picking intersection.
+    pub hit: HitData,
+    /// Duration between the pointer pressed and lifted for this click
+    pub duration: Duration,
+}
+
+#[derive(Resource, Deref, DerefMut, Default)]
+struct DragCancelClickState(HashMap<Entity, Instant>);


### PR DESCRIPTION
- Moved selection code to its own module
- Added helper methods to `SelectedEntity`, and some observer system handlers
- Made the plane selectable by clicking it in the scene
- Hacked together the excellently named `Pointer<DragCancelClick>` event. It only responds to clicks without pointer movement to prevent double interactions with draggable entities, or camera controllers.