### PR TITLE
Allow loading gltf/glb files from outside the assets directory

### DIFF
--- a/crates/bevy_editor/src/lib.rs
+++ b/crates/bevy_editor/src/lib.rs
@@ -12,6 +12,7 @@
 //! - Finally, it will be a standalone application that communicates with a running Bevy game via the Bevy Remote Protocol.
 
 use bevy::app::App as BevyApp;
+use bevy::asset::UnapprovedPathMode;
 use bevy::prelude::*;
 // Re-export Bevy for project use
 pub use bevy;
@@ -36,7 +37,10 @@ pub struct RuntimePlugin;
 
 impl Plugin for RuntimePlugin {
     fn build(&self, bevy_app: &mut BevyApp) {
-        bevy_app.add_plugins(DefaultPlugins);
+        bevy_app.add_plugins(DefaultPlugins.set(AssetPlugin {
+            unapproved_path_mode: UnapprovedPathMode::Deny,
+            ..default()
+        }));
     }
 }
 

--- a/crates/bevy_editor/src/load_gltf.rs
+++ b/crates/bevy_editor/src/load_gltf.rs
@@ -23,7 +23,7 @@ fn file_dropped(
     for event in event_reader.read() {
         if let FileDragAndDrop::DroppedFile { path_buf, .. } = event {
             let asset_path = GltfAssetLabel::Scene(0).from_asset(path_buf.clone());
-            commands.spawn(SceneRoot(asset_server.load(asset_path)));
+            commands.spawn(SceneRoot(asset_server.load_override(asset_path)));
         }
     }
 }
@@ -68,6 +68,6 @@ fn poll_pick_gltf(
     if let Some(file) = result {
         let path = file.path().to_owned();
         let asset_path = GltfAssetLabel::Scene(0).from_asset(path);
-        commands.spawn(SceneRoot(asset_server.load(asset_path)));
+        commands.spawn(SceneRoot(asset_server.load_override(asset_path)));
     }
 }


### PR DESCRIPTION
Reminder that you can drag & drop gltf/glb files onto the editor to load them *(broken on wayland)*, or press `ctrl+L` to open a file picker.