### PR TITLE
Port Viewport Panes to BSN and Feathers

### DIFF
--- a/crates/bevy_editor/src/lib.rs
+++ b/crates/bevy_editor/src/lib.rs
@@ -11,12 +11,20 @@
 //!   which transforms the user's application into an editor that runs their game.
 //! - Finally, it will be a standalone application that communicates with a running Bevy game via the Bevy Remote Protocol.
 
+use std::time::Duration;
+
 use bevy::app::App as BevyApp;
 use bevy::asset::UnapprovedPathMode;
 use bevy::prelude::*;
+use bevy::{
+    core_widgets::CoreWidgetsPlugins,
+    feathers::{FeathersPlugin, dark_theme::create_dark_theme, theme::UiTheme},
+    input_focus::{InputDispatchPlugin, tab_navigation::TabNavigationPlugin},
+};
 // Re-export Bevy for project use
 pub use bevy;
 
+use bevy::winit::{UpdateMode, WinitSettings};
 use bevy_context_menu::ContextMenuPlugin;
 use bevy_editor_core::EditorCorePlugin;
 use bevy_editor_core::selection::common_handlers::toggle_select_on_click;
@@ -64,11 +72,20 @@ impl Plugin for EditorPlugin {
                 AssetBrowserPanePlugin,
                 LoadGltfPlugin,
                 MeshPickingPlugin,
+                CoreWidgetsPlugins,
+                InputDispatchPlugin,
+                TabNavigationPlugin,
+                FeathersPlugin,
             ))
             .insert_resource(MeshPickingSettings {
                 // Workaround for the Mesh2d circle blocking picking in the 3d viewport (even though it is not visible).
                 require_markers: true,
                 ..default()
+            })
+            .insert_resource(UiTheme(create_dark_theme()))
+            .insert_resource(WinitSettings {
+                focused_mode: UpdateMode::reactive(Duration::from_secs_f64(1.0 / 60.0)),
+                unfocused_mode: UpdateMode::reactive_low_power(Duration::from_secs(1)),
             })
             .add_systems(Startup, dummy_setup);
     }

--- a/crates/bevy_pane_layout/src/components.rs
+++ b/crates/bevy_pane_layout/src/components.rs
@@ -1,0 +1,54 @@
+//! Pane UI components module.
+
+use bevy::{
+    ecs::template::template,
+    feathers::containers::{pane, pane_body, pane_header},
+    prelude::*,
+    scene2::{Scene, bsn},
+};
+
+use crate::{PaneContentNode, PaneHeaderNode, ui::header_context_menu};
+
+/// A standard editor pane.
+pub fn editor_pane() -> impl Scene {
+    bsn! {
+        :pane
+        :fit_to_parent
+        Node {
+            margin: UiRect::all(Val::Px(1.)),
+        }
+    }
+}
+
+/// A standard editor pane header.
+pub fn editor_pane_header() -> impl Scene {
+    bsn! {
+        :pane_header
+        PaneHeaderNode
+        template(|_| Ok(header_context_menu()))
+    }
+}
+
+/// A standard editor pane body.
+pub fn editor_pane_body() -> impl Scene {
+    bsn! {
+        :pane_body
+        PaneContentNode
+        Node {
+            flex_grow: 1.,
+        }
+    }
+}
+
+/// Align this node's position and size with its parent.
+pub fn fit_to_parent() -> impl Scene {
+    bsn! {
+        Node {
+            position_type: PositionType::Absolute,
+            top: Val::ZERO,
+            bottom: Val::ZERO,
+            left: Val::ZERO,
+            right: Val::ZERO,
+        }
+    }
+}

--- a/crates/bevy_pane_layout/src/lib.rs
+++ b/crates/bevy_pane_layout/src/lib.rs
@@ -1,5 +1,6 @@
 //! Resizable, divider-able panes for Bevy.
 
+pub mod components;
 mod handlers;
 mod pane_drop_area;
 pub mod registry;
@@ -30,6 +31,7 @@ use crate::{
 pub mod prelude {
     pub use crate::{
         PaneAreaNode, PaneContentNode, PaneHeaderNode,
+        components::*,
         registry::{PaneAppExt, PaneStructure},
     };
 }
@@ -189,13 +191,13 @@ struct PaneRootNode {
 }
 
 /// Node to denote the area of the Pane.
-#[derive(Component)]
+#[derive(Component, Clone, Default)]
 pub struct PaneAreaNode;
 
 /// Node to add widgets into the header of a Pane.
-#[derive(Component)]
+#[derive(Component, Clone, Default)]
 pub struct PaneHeaderNode;
 
 /// Node to denote the content space of the Pane.
-#[derive(Component)]
+#[derive(Component, Clone, Default)]
 pub struct PaneContentNode;

--- a/crates/bevy_pane_layout/src/ui.rs
+++ b/crates/bevy_pane_layout/src/ui.rs
@@ -7,6 +7,20 @@ use crate::{
     Size, handlers::*, registry::PaneStructure,
 };
 
+pub fn header_context_menu() -> ContextMenu {
+    ContextMenu::new([
+        ContextMenuOption::new("Close", |mut commands, entity| {
+            commands.run_system_cached_with(remove_pane, entity);
+        }),
+        ContextMenuOption::new("Split - Horizontal", |mut commands, entity| {
+            commands.run_system_cached_with(split_pane, (entity, false));
+        }),
+        ContextMenuOption::new("Split - Vertical", |mut commands, entity| {
+            commands.run_system_cached_with(split_pane, (entity, true));
+        }),
+    ])
+}
+
 pub(crate) fn spawn_pane<'a>(
     commands: &'a mut Commands,
     theme: &Theme,
@@ -57,17 +71,7 @@ pub(crate) fn spawn_pane<'a>(
             },
             theme.pane.header_background_color,
             theme.pane.header_border_radius,
-            ContextMenu::new([
-                ContextMenuOption::new("Close", |mut commands, entity| {
-                    commands.run_system_cached_with(remove_pane, entity);
-                }),
-                ContextMenuOption::new("Split - Horizontal", |mut commands, entity| {
-                    commands.run_system_cached_with(split_pane, (entity, false));
-                }),
-                ContextMenuOption::new("Split - Vertical", |mut commands, entity| {
-                    commands.run_system_cached_with(split_pane, (entity, true));
-                }),
-            ]),
+            header_context_menu(),
             PaneHeaderNode,
             ChildOf(area),
         ))


### PR DESCRIPTION
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/9852fd35-57c7-4285-bb7c-651bee858f43" />

- This also sets the winit `UpdateMode` to 'reactive' at 60hz to reduce power draw on systems with high refresh-rate displays
- There are some `.insert(Node::default())` sprinkled together with `spawn_scene` because of some bug where child UI nodes might not appear otherwise.