### PR TITLE
Humble Beginnings for the `ActionRegistry`

### DIFF
--- a/crates/bevy_editor/src/load_gltf.rs
+++ b/crates/bevy_editor/src/load_gltf.rs
@@ -4,6 +4,7 @@ use bevy::{
     prelude::*,
     tasks::{AsyncComputeTaskPool, Task, block_on, futures_lite::future},
 };
+use bevy_editor_core::prelude::*;
 use rfd::{AsyncFileDialog, FileHandle};
 
 pub(crate) struct LoadGltfPlugin;
@@ -11,7 +12,9 @@ pub(crate) struct LoadGltfPlugin;
 impl Plugin for LoadGltfPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<GltfFilepickerTask>()
-            .add_systems(Update, (pick_gltf, poll_pick_gltf, file_dropped));
+            .add_systems(Update, (poll_pick_gltf, file_dropped))
+            .register_action("load-gltf", "Load GLTF", pick_gltf_action)
+            .register_action_binding("load-gltf", [KeyCode::ControlLeft, KeyCode::KeyL]);
     }
 }
 
@@ -21,7 +24,10 @@ fn file_dropped(
     mut event_reader: EventReader<FileDragAndDrop>,
 ) {
     for event in event_reader.read() {
-        if let FileDragAndDrop::DroppedFile { path_buf, .. } = event {
+        if let FileDragAndDrop::DroppedFile { path_buf, .. } = event
+            && let Some(extension) = path_buf.extension()
+            && (extension == "gtlf" || extension == "glb")
+        {
             let asset_path = GltfAssetLabel::Scene(0).from_asset(path_buf.clone());
             commands.spawn(SceneRoot(asset_server.load_override(asset_path)));
         }
@@ -31,24 +37,18 @@ fn file_dropped(
 #[derive(Resource, Default)]
 pub(crate) struct GltfFilepickerTask(Option<Task<Option<FileHandle>>>);
 
-pub(crate) fn pick_gltf(
-    mut file_picker_task: ResMut<GltfFilepickerTask>,
-    keyboard_input: Res<ButtonInput<KeyCode>>,
-) {
+pub(crate) fn pick_gltf_action(mut file_picker_task: ResMut<GltfFilepickerTask>) {
     if file_picker_task.0.is_some() {
         return;
     }
-
-    if keyboard_input.pressed(KeyCode::ControlLeft) && keyboard_input.just_pressed(KeyCode::KeyL) {
-        file_picker_task.0 = Some(
-            AsyncComputeTaskPool::get().spawn(
-                AsyncFileDialog::new()
-                    .set_title("Load GLTF file")
-                    .add_filter("gltf/glb", &["gltf", "glb"])
-                    .pick_file(),
-            ),
-        );
-    }
+    file_picker_task.0 = Some(
+        AsyncComputeTaskPool::get().spawn(
+            AsyncFileDialog::new()
+                .set_title("Load GLTF file")
+                .add_filter("gltf/glb", &["gltf", "glb"])
+                .pick_file(),
+        ),
+    );
 }
 
 fn poll_pick_gltf(
@@ -56,18 +56,14 @@ fn poll_pick_gltf(
     asset_server: Res<AssetServer>,
     mut commands: Commands,
 ) {
-    let Some(task) = &mut file_picker_task.0 else {
-        return;
-    };
-
-    let Some(result) = block_on(future::poll_once(task)) else {
-        return;
-    };
-    file_picker_task.0 = None;
-
-    if let Some(file) = result {
-        let path = file.path().to_owned();
-        let asset_path = GltfAssetLabel::Scene(0).from_asset(path);
-        commands.spawn(SceneRoot(asset_server.load_override(asset_path)));
+    if let Some(task) = &mut file_picker_task.0
+        && let Some(result) = block_on(future::poll_once(task))
+    {
+        file_picker_task.0 = None;
+        if let Some(file) = result {
+            let path = file.path().to_owned();
+            let asset_path = GltfAssetLabel::Scene(0).from_asset(path);
+            commands.spawn(SceneRoot(asset_server.load_override(asset_path)));
+        }
     }
 }

--- a/crates/bevy_editor_core/src/actions.rs
+++ b/crates/bevy_editor_core/src/actions.rs
@@ -1,0 +1,174 @@
+//! Editor actions module.
+
+use bevy::{ecs::system::SystemId, prelude::*};
+
+/// Editor selection plugin.
+#[derive(Default)]
+pub struct ActionsPlugin;
+
+impl Plugin for ActionsPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ActionRegistry>()
+            .init_resource::<ActionBindings>()
+            .add_systems(Update, run_actions_on_binding);
+    }
+}
+
+fn run_actions_on_binding(world: &mut World) {
+    world.resource_scope(|world, mut bindings: Mut<ActionBindings>| {
+        world.resource_scope(|world, input: Mut<ButtonInput<KeyCode>>| {
+            // Sort by the invserse amount of keys in the binding so that simpler keybinds don't prevent more complex ones from triggering.
+            bindings.list.sort_by_key(|(v, _)| usize::MAX - v.len());
+            'outer: for (binding, action_id) in &bindings.list {
+                if let Some(last_key) = binding.last() {
+                    for key in &binding[..(binding.len() - 1)] {
+                        if !input.pressed(*key) {
+                            continue 'outer;
+                        }
+                    }
+                    if input.just_pressed(*last_key) {
+                        world.run_action(action_id);
+                        break 'outer;
+                    }
+                }
+            }
+        });
+    });
+}
+
+/// The registry for [`Action`]s
+#[derive(Resource, Default)]
+pub struct ActionRegistry {
+    actions: Vec<Action>,
+}
+
+impl ActionRegistry {
+    /// Register an action.
+    pub fn register(
+        &mut self,
+        id: impl Into<String>,
+        label: impl Into<String>,
+        system_id: SystemId<(), ()>,
+    ) {
+        self.actions.push(Action {
+            id: id.into(),
+            label: label.into(),
+            system_id,
+        });
+    }
+
+    /// Run an action.
+    pub fn run(&mut self, world: &mut World, action_id: impl Into<String>) {
+        let action_id = action_id.into();
+        if let Some(action) = self.actions.iter_mut().find(|ac| ac.id == action_id)
+            && let Err(error) = world.run_system(action.system_id)
+        {
+            error!("Failed to run action '{}': {}", action.id, error);
+        }
+    }
+}
+
+/// List of keybindings to [`Action`]s
+#[derive(Resource, Default)]
+pub struct ActionBindings {
+    list: Vec<(Vec<KeyCode>, String)>,
+}
+
+impl ActionBindings {
+    /// Add a binding for an action.
+    pub fn add_binding(
+        &mut self,
+        action_id: impl Into<String>,
+        binding: impl IntoIterator<Item = KeyCode>,
+    ) {
+        self.list
+            .push((binding.into_iter().collect(), action_id.into()));
+    }
+}
+
+/// Defines some action with an id and a label for display.
+pub struct Action {
+    id: String,
+    #[expect(dead_code)]
+    label: String,
+    system_id: SystemId,
+}
+
+/// [`ActionRegistry`] extension trait for [`App`].
+pub trait ActionAppExt {
+    /// Register an action.
+    fn register_action<M>(
+        &mut self,
+        id: impl Into<String>,
+        label: impl Into<String>,
+        system: impl IntoSystem<(), (), M> + 'static,
+    ) -> &mut Self;
+
+    /// Register an action binding.
+    fn register_action_binding(
+        &mut self,
+        action_id: impl Into<String>,
+        binding: impl IntoIterator<Item = KeyCode>,
+    ) -> &mut Self;
+}
+
+impl ActionAppExt for App {
+    fn register_action<M>(
+        &mut self,
+        id: impl Into<String>,
+        label: impl Into<String>,
+        system: impl IntoSystem<(), (), M> + 'static,
+    ) -> &mut Self {
+        let system_id = self.world_mut().register_system(system);
+        self.world_mut()
+            .get_resource_or_init::<ActionRegistry>()
+            .register(id, label, system_id);
+        self
+    }
+
+    fn register_action_binding(
+        &mut self,
+        action_id: impl Into<String>,
+        binding: impl IntoIterator<Item = KeyCode>,
+    ) -> &mut Self {
+        self.world_mut()
+            .get_resource_or_init::<ActionBindings>()
+            .add_binding(action_id, binding);
+        self
+    }
+}
+
+/// [`ActionRegistry`] extension trait for [`World`].
+pub trait ActionWorldExt {
+    /// Run an action.
+    fn run_action(&mut self, id: impl Into<String>) -> &mut Self;
+}
+
+impl ActionWorldExt for World {
+    fn run_action(&mut self, id: impl Into<String>) -> &mut Self {
+        self.resource_scope(|world, mut registry: Mut<ActionRegistry>| registry.run(world, id));
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_action() {
+        #[derive(Resource)]
+        struct Counter(u32);
+        let mut app = App::new();
+        app.insert_resource(Counter(0));
+        app.insert_resource(ActionRegistry::default());
+
+        app.register_action("action", "Action", |mut counter: ResMut<Counter>| {
+            counter.0 += 1;
+        });
+
+        app.world_mut().run_action("action");
+
+        assert_eq!(app.world().resource::<Counter>().0, 1);
+    }
+}

--- a/crates/bevy_editor_core/src/lib.rs
+++ b/crates/bevy_editor_core/src/lib.rs
@@ -1,11 +1,17 @@
 //! This crate provides core functionality for the Bevy Engine Editor.
 
+pub mod actions;
 pub mod selection;
 pub mod utils;
 
 use bevy::prelude::*;
 
-use crate::{selection::SelectionPlugin, utils::CoreUtilsPlugin};
+use crate::{actions::ActionsPlugin, selection::SelectionPlugin, utils::CoreUtilsPlugin};
+
+/// Crate prelude.
+pub mod prelude {
+    pub use crate::actions::{ActionAppExt, ActionWorldExt};
+}
 
 /// Core plugin for the editor.
 #[derive(Default)]
@@ -13,6 +19,6 @@ pub struct EditorCorePlugin;
 
 impl Plugin for EditorCorePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((SelectionPlugin, CoreUtilsPlugin));
+        app.add_plugins((ActionsPlugin, SelectionPlugin, CoreUtilsPlugin));
     }
 }


### PR DESCRIPTION
This adds a registry of 'actions', also known as [commands](https://code.visualstudio.com/api/ux-guidelines/command-palette) in VS Code, or [operators](https://docs.blender.org/manual/en/4.5/interface/operators.html) in Blender.
There's also rudimentary support for keyboard shortcuts.