### PR TITLE
Document the Lucide placeholder icon font

### DIFF
--- a/design-book/src/SUMMARY.md
+++ b/design-book/src/SUMMARY.md
@@ -11,3 +11,4 @@
     - [Best Practices](./best-practices.md)
     - [Writing Style](./writing-style.md)
     - [Pane Layout](./pane-layout.md)
+    - [Themes and Styles](./styles.md)

--- a/design-book/src/styles.md
+++ b/design-book/src/styles.md
@@ -1,2 +1,22 @@
 # Themes and Styles
 
+The editor uses a number of style rules for best-practice accessibility and clarity.
+
+<!--
+## Colors
+
+TODO.
+
+## Fonts
+
+TODO.
+-->
+
+## Icons
+
+We're temporarily using [the Lucide icon set](https://lucide.dev/) for icons in the editor.[^lucide_pr] It's a helpful placeholder, as it includes a great deal of icons helpful for denoting game development operations. Lucide is also a font, making it easier to include in modern versions of Bevy.
+
+[^lucide_pr]:
+    Contributors introduced it [in PR #213](https://github.com/bevyengine/bevy_editor_prototypes/pull/213) for some helpful placeholders. Since its a font, Bevy doesn't need SVG support to include it!
+
+    Additional or different icons will be designed/chosen in the future.

--- a/design-book/src/styles.md
+++ b/design-book/src/styles.md
@@ -1,0 +1,2 @@
+# Themes and Styles
+


### PR DESCRIPTION
# Objective

The current placeholder icon set, Lucide, isn't currently documented. 

I added a page to the design book to help contributors find the font (and, in the future, discover other design choices in the Editor).

## Solution

- Added a new page to the design book (`styles.md`)
- Stuck that into the mdBook `SUMMARY.md`
- Added a section about the current font (Lucide)

## Testing

I used `mdbook serve` and checked out my changes - they seem to work just fine! :)