### PR TITLE
Transform Gizmo

### DIFF
--- a/bevy_editor_panes/bevy_3d_viewport/Cargo.toml
+++ b/bevy_editor_panes/bevy_3d_viewport/Cargo.toml
@@ -11,6 +11,7 @@ bevy_editor_styles.workspace = true
 bevy_infinite_grid.workspace = true
 bevy_editor_core.workspace = true
 bevy_render.workspace = true
+bevy_transform_gizmos.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bevy_editor/Cargo.toml
+++ b/crates/bevy_editor/Cargo.toml
@@ -5,23 +5,27 @@ edition = "2024"
 
 [dependencies]
 bevy.workspace = true
+
+# Editor
+bevy_editor_core.workspace = true
 bevy_pane_layout.workspace = true
 bevy_menu_bar.workspace = true
 bevy_footer_bar.workspace = true
 bevy_context_menu.workspace = true
 bevy_editor_styles.workspace = true
-
-serde.workspace = true
-ron.workspace = true
-rfd.workspace = true
+bevy_transform_gizmos.workspace = true
 
 # Panes
-bevy_editor_core.workspace = true
 bevy_3d_viewport.workspace = true
 bevy_2d_viewport.workspace = true
 bevy_scene_tree.workspace = true
 bevy_properties_pane.workspace = true
 bevy_asset_browser.workspace = true
+
+# Third party
+serde.workspace = true
+ron.workspace = true
+rfd.workspace = true
 
 [lints]
 workspace = true

--- a/crates/bevy_editor_cam/src/controller/component.rs
+++ b/crates/bevy_editor_cam/src/controller/component.rs
@@ -47,6 +47,8 @@ use super::{
 /// 3. When the motion should end, call  [`EditorCam::end_move`].
 #[derive(Debug, Clone, Reflect, Component)]
 pub struct EditorCam {
+    /// Controls whether any motions are allowed. The ongoing motion will be canceled if set to `false`.
+    pub enabled: bool,
     /// What input motions are currently allowed?
     pub enabled_motion: EnabledMotion,
     /// The type of camera orbit to use.
@@ -83,6 +85,7 @@ pub struct EditorCam {
 impl Default for EditorCam {
     fn default() -> Self {
         EditorCam {
+            enabled: true,
             orbit_constraint: Default::default(),
             zoom_limits: Default::default(),
             smoothing: Default::default(),

--- a/crates/bevy_transform_gizmos/src/lib.rs
+++ b/crates/bevy_transform_gizmos/src/lib.rs
@@ -558,7 +558,7 @@ fn gizmo_cam_copy_settings(
         }
         if main_cam.is_changed() {
             *gizmo_cam = main_cam.clone();
-            gizmo_cam.order += 10;
+            gizmo_cam.order += 1;
         }
         if main_proj.is_changed() {
             *proj = main_proj.clone();


### PR DESCRIPTION
- Follows up on #236, doing the final fix-ups needed to get the transform gizmo working within the 3d viewport.

I chose to remove the 2d circle mesh for now as it gets in the way of picking despite being invisible in the 3d viewport, and the workaround gets annoying here.
Added a box to and tweaked the scene so it's a little more interesting.

Known issue: The editor cam can anchor onto the gizmo (rather than the scene entities behind it). Would require something like per pointer filters for picking, or perhaps the mesh picking backend could optionally try to check whether a mesh is visible to some camera.