### PR TITLE
Update Bevy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: --deny warnings
+  RUSTFLAGS: --deny warnings -C debuginfo=line-tables-only
   RUSTDOCFLAGS: --deny warnings
   # This can be any valid Cargo version requirement, but should start with a caret `^` to opt-in to
   # SemVer-compatible changes. Please keep this in sync with `book.yaml`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/cart/bevy.git", rev = "40e6f12bbad44dfe2566fda2ead83469d53717d0", features = [
+bevy = { git = "https://github.com/tim-blackbird/bevy.git", rev = "a7ee6690049e8021163490faf6cb67022c7831d7", features = [
     "wayland",
     "experimental_bevy_feathers",
 ] }
-bevy_render = { git = "https://github.com/cart/bevy.git", rev = "40e6f12bbad44dfe2566fda2ead83469d53717d0" }
-bevy_derive = { git = "https://github.com/cart/bevy.git", rev = "40e6f12bbad44dfe2566fda2ead83469d53717d0" }
-bevy_macro_utils = { git = "https://github.com/cart/bevy.git", rev = "40e6f12bbad44dfe2566fda2ead83469d53717d0" }
+bevy_render = { git = "https://github.com/tim-blackbird/bevy.git", rev = "a7ee6690049e8021163490faf6cb67022c7831d7" }
+bevy_derive = { git = "https://github.com/tim-blackbird/bevy.git", rev = "a7ee6690049e8021163490faf6cb67022c7831d7" }
+bevy_macro_utils = { git = "https://github.com/tim-blackbird/bevy.git", rev = "a7ee6690049e8021163490faf6cb67022c7831d7" }
 thiserror = "2.0"
 serde = { version = "1", features = ["derive"] }
 tracing-test = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/tim-blackbird/bevy.git", rev = "a7ee6690049e8021163490faf6cb67022c7831d7", features = [
+bevy = { git = "https://github.com/cart/bevy.git", rev = "05b79c229a070224c007994e5c2be8b67439d7d9", features = [
     "wayland",
     "experimental_bevy_feathers",
 ] }
-bevy_render = { git = "https://github.com/tim-blackbird/bevy.git", rev = "a7ee6690049e8021163490faf6cb67022c7831d7" }
-bevy_derive = { git = "https://github.com/tim-blackbird/bevy.git", rev = "a7ee6690049e8021163490faf6cb67022c7831d7" }
-bevy_macro_utils = { git = "https://github.com/tim-blackbird/bevy.git", rev = "a7ee6690049e8021163490faf6cb67022c7831d7" }
+bevy_render = { git = "https://github.com/cart/bevy.git", rev = "05b79c229a070224c007994e5c2be8b67439d7d9" }
+bevy_derive = { git = "https://github.com/cart/bevy.git", rev = "05b79c229a070224c007994e5c2be8b67439d7d9" }
+bevy_macro_utils = { git = "https://github.com/cart/bevy.git", rev = "05b79c229a070224c007994e5c2be8b67439d7d9" }
 thiserror = "2.0"
 serde = { version = "1", features = ["derive"] }
 tracing-test = "0.2.5"

--- a/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
@@ -127,7 +127,6 @@ fn on_pane_creation(
                 ],
             ]
         })
-        .insert(Node::default())
         .insert(ChildOf(structure.root));
 
     commands

--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -203,7 +203,6 @@ fn on_pane_creation(
                 ],
             ]
         })
-        .insert(Node::default())
         .insert(ChildOf(structure.root));
 
     let camera_id = commands

--- a/bevy_editor_panes/bevy_asset_browser/src/ui/nodes.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/ui/nodes.rs
@@ -3,9 +3,9 @@
 use atomicow::CowArc;
 use bevy::{
     asset::io::{AssetSource, AssetSourceBuilders, AssetSourceId},
+    feathers::cursor::EntityCursor,
     prelude::*,
     window::SystemCursorIcon,
-    winit::cursor::CursorIcon,
 };
 use bevy_context_menu::{ContextMenu, ContextMenuOption};
 use bevy_editor_styles::Theme;
@@ -200,7 +200,7 @@ pub(crate) fn spawn_file_node<'a>(
 }
 
 fn spawn_base_node<'a>(commands: &'a mut Commands, theme: &Res<Theme>) -> EntityCommands<'a> {
-    let mut base_node_ec = commands.spawn((
+    commands.spawn((
         Button,
         Node {
             margin: UiRect::all(Val::Px(5.0)),
@@ -215,30 +215,6 @@ fn spawn_base_node<'a>(commands: &'a mut Commands, theme: &Res<Theme>) -> Entity
         },
         ZIndex(1),
         theme.general.border_radius,
-    ));
-
-    // Hover effect
-    base_node_ec
-        .observe(
-            move |_trigger: On<Pointer<Move>>,
-                  window_query: Query<Entity, With<Window>>,
-                  mut commands: Commands| {
-                let window = window_query.single().unwrap();
-                commands
-                    .entity(window)
-                    .insert(CursorIcon::System(SystemCursorIcon::Pointer));
-            },
-        )
-        .observe(
-            move |_trigger: On<Pointer<Out>>,
-                  window_query: Query<Entity, With<Window>>,
-                  mut commands: Commands| {
-                let window = window_query.single().unwrap();
-                commands
-                    .entity(window)
-                    .insert(CursorIcon::System(SystemCursorIcon::Default));
-            },
-        );
-
-    base_node_ec
+        EntityCursor::System(SystemCursorIcon::Pointer),
+    ))
 }

--- a/bevy_editor_panes/bevy_asset_browser/src/ui/top_bar.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/ui/top_bar.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, window::SystemCursorIcon, winit::cursor::CursorIcon};
+use bevy::{feathers::cursor::EntityCursor, prelude::*, window::SystemCursorIcon};
 use bevy_editor_styles::Theme;
 
 use crate::{AssetBrowserLocation, io};
@@ -130,6 +130,7 @@ fn spawn_path_segment_ui<'a>(
         BackgroundColor(PATH_SEGMENT_BACKGROUND_COLOR),
         theme.general.border_radius,
         segment_type,
+        EntityCursor::System(SystemCursorIcon::Pointer),
     ));
     segment_ec
         .with_children(|parent| {
@@ -177,26 +178,6 @@ fn spawn_path_segment_ui<'a>(
                     }
                 };
                 commands.run_system_cached(io::task::fetch_directory_content);
-            },
-        )
-        .observe(
-            move |_trigger: On<Pointer<Move>>,
-                  window_query: Query<Entity, With<Window>>,
-                  mut commands: Commands| {
-                let window = window_query.single().unwrap();
-                commands
-                    .entity(window)
-                    .insert(CursorIcon::System(SystemCursorIcon::Pointer));
-            },
-        )
-        .observe(
-            move |_trigger: On<Pointer<Out>>,
-                  window_query: Query<Entity, With<Window>>,
-                  mut commands: Commands| {
-                let window = window_query.single().unwrap();
-                commands
-                    .entity(window)
-                    .insert(CursorIcon::System(SystemCursorIcon::Default));
             },
         );
     segment_ec

--- a/bevy_editor_panes/bevy_properties_pane/src/lib.rs
+++ b/bevy_editor_panes/bevy_properties_pane/src/lib.rs
@@ -43,7 +43,6 @@ fn setup_pane(pane: In<PaneStructure>, mut commands: Commands) {
                 PropertiesPaneBody
             ]
         })
-        .insert(Node::default())
         .insert(ChildOf(pane.root));
 }
 
@@ -57,7 +56,6 @@ fn update_properties_pane(
         commands.entity(pane_body).despawn_children();
         commands
             .spawn_scene(properties_pane(&selection, world))
-            .insert(Node::default())
             .insert(ChildOf(pane_body));
     }
 }

--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, window::SystemCursorIcon, winit::cursor::CursorIcon};
+use bevy::{feathers::cursor::EntityCursor, prelude::*, window::SystemCursorIcon};
 use bevy_editor_styles::Theme;
 
 use crate::ContextMenu;
@@ -55,6 +55,7 @@ pub(crate) fn spawn_option<'a>(
                 ..default()
             },
             theme.context_menu.option_border_radius,
+            EntityCursor::System(SystemCursorIcon::Pointer),
         ))
         .observe(
             |trigger: On<Pointer<Over>>,
@@ -66,26 +67,6 @@ pub(crate) fn spawn_option<'a>(
         .observe(
             |trigger: On<Pointer<Out>>, mut query: Query<&mut BackgroundColor>| {
                 query.get_mut(trigger.target()).unwrap().0 = Color::NONE;
-            },
-        )
-        .observe(
-            move |_trigger: On<Pointer<Over>>,
-                  window_query: Query<Entity, With<Window>>,
-                  mut commands: Commands| {
-                let window = window_query.single().unwrap();
-                commands
-                    .entity(window)
-                    .insert(CursorIcon::System(SystemCursorIcon::Pointer));
-            },
-        )
-        .observe(
-            |_trigger: On<Pointer<Out>>,
-             window_query: Query<Entity, With<Window>>,
-             mut commands: Commands| {
-                let window = window_query.single().unwrap();
-                commands
-                    .entity(window)
-                    .insert(CursorIcon::System(SystemCursorIcon::Default));
             },
         )
         .observe(

--- a/bevy_widgets/bevy_text_editing/src/editable_text_line/input.rs
+++ b/bevy_widgets/bevy_text_editing/src/editable_text_line/input.rs
@@ -88,10 +88,10 @@ pub fn on_key_input(
         // Process modifier key combinations
         match &input.key_code {
             KeyCode::KeyC => {
-                if let Some(selected_text) = text_field.get_selected_text() {
-                    if let Err(e) = clipboard.set_text(selected_text) {
-                        warn!("Clipboard error: {}", e);
-                    }
+                if let Some(selected_text) = text_field.get_selected_text()
+                    && let Err(e) = clipboard.set_text(selected_text)
+                {
+                    warn!("Clipboard error: {}", e);
                 }
             }
             KeyCode::KeyV => match clipboard.get_text() {
@@ -114,10 +114,10 @@ pub fn on_key_input(
                 }
             },
             KeyCode::KeyX => {
-                if let Some(selected_text) = text_field.get_selected_text() {
-                    if let Err(e) = clipboard.set_text(selected_text) {
-                        warn!("Clipboard error: {}", e);
-                    }
+                if let Some(selected_text) = text_field.get_selected_text()
+                    && let Err(e) = clipboard.set_text(selected_text)
+                {
+                    warn!("Clipboard error: {}", e);
                 }
                 if let Some(selected_range) = text_field.selection_range() {
                     text_change = TextChange::remove_change(selected_range);
@@ -137,10 +137,10 @@ pub fn on_key_input(
         // Process regular (non-modifier) key press
         match &input.logical_key {
             Key::Space => {
-                if let Some(allowed_chars) = &text_field.allowed_chars {
-                    if !allowed_chars.contains(&' ') {
-                        return;
-                    }
+                if let Some(allowed_chars) = &text_field.allowed_chars
+                    && !allowed_chars.contains(&' ')
+                {
+                    return;
                 }
 
                 if let Some((start, end)) = text_field.selection_range() {
@@ -269,11 +269,11 @@ pub fn update_has_focus(
                 // Gained focus
                 commands.entity(entity).insert(HasFocus(true));
 
-                if let Ok(mut text_field) = q_editable_texts.get_mut(entity) {
-                    if text_field.cursor_position.is_none() {
-                        text_field.cursor_position = Some(CharPosition(0));
-                        commands.trigger_targets(RenderWidget::show_cursor(), entity);
-                    }
+                if let Ok(mut text_field) = q_editable_texts.get_mut(entity)
+                    && text_field.cursor_position.is_none()
+                {
+                    text_field.cursor_position = Some(CharPosition(0));
+                    commands.trigger_targets(RenderWidget::show_cursor(), entity);
                 }
             }
         } else if has_focus.0 {

--- a/crates/bevy_editor_settings/src/file_system/de/mod.rs
+++ b/crates/bevy_editor_settings/src/file_system/de/mod.rs
@@ -241,15 +241,15 @@ pub fn load_preferences(world: &mut World, table: toml::Table, settings_type: Se
                             .map(|key| key.0.to_string())
                             .unwrap_or_else(|| enm.reflect_type_ident().unwrap().to_snake_case());
 
-                        if let Some(table) = table.get(&name).and_then(|v| v.as_table()) {
-                            if let Some(value) = table.get("variant") {
-                                LoadEnum {
-                                    enum_info,
-                                    enm,
-                                    toml_value: value,
-                                }
-                                .load_enum();
+                        if let Some(table) = table.get(&name).and_then(|v| v.as_table())
+                            && let Some(value) = table.get("variant")
+                        {
+                            LoadEnum {
+                                enum_info,
+                                enm,
+                                toml_value: value,
                             }
+                            .load_enum();
                         }
                     }
                 }
@@ -274,17 +274,16 @@ pub fn load_preferences(world: &mut World, table: toml::Table, settings_type: Se
                             tuple_struct.reflect_type_ident().unwrap().to_snake_case()
                         });
 
-                        if let Some(table) = table.get(&name).and_then(|v| v.as_table()) {
-                            if let Some(array_value) =
+                        if let Some(table) = table.get(&name).and_then(|v| v.as_table())
+                            && let Some(array_value) =
                                 table.get("fields").and_then(|v| v.as_array())
-                            {
-                                LoadTupleStruct {
-                                    tuple_struct_info,
-                                    table: array_value,
-                                    tuple_struct,
-                                }
-                                .load_tuple_struct();
+                        {
+                            LoadTupleStruct {
+                                tuple_struct_info,
+                                table: array_value,
+                                tuple_struct,
                             }
+                            .load_tuple_struct();
                         }
                     }
                 }

--- a/crates/bevy_editor_settings/src/file_system/mod.rs
+++ b/crates/bevy_editor_settings/src/file_system/mod.rs
@@ -14,11 +14,11 @@ pub fn global_settings_path() -> Option<PathBuf> {
     let config_dir = path.config_dir();
     let path = config_dir.join(SETTINGS_BASE_DIR);
 
-    if !path.exists() {
-        if let Err(e) = std::fs::create_dir_all(&path) {
-            error!("Failed to create global settings directory: {}", e);
-            return None;
-        }
+    if !path.exists()
+        && let Err(e) = std::fs::create_dir_all(&path)
+    {
+        error!("Failed to create global settings directory: {}", e);
+        return None;
     }
     Some(path)
 }

--- a/crates/bevy_pane_layout/src/ui.rs
+++ b/crates/bevy_pane_layout/src/ui.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, window::SystemCursorIcon, winit::cursor::CursorIcon};
+use bevy::{feathers::cursor::EntityCursor, prelude::*, window::SystemCursorIcon};
 use bevy_context_menu::{ContextMenu, ContextMenuOption};
 use bevy_editor_styles::{Theme, icons};
 
@@ -74,27 +74,8 @@ pub(crate) fn spawn_pane<'a>(
             header_context_menu(),
             PaneHeaderNode,
             ChildOf(area),
+            EntityCursor::System(SystemCursorIcon::Pointer),
         ))
-        .observe(
-            move |_trigger: On<Pointer<Move>>,
-                  window_query: Query<Entity, With<Window>>,
-                  mut commands: Commands| {
-                let window = window_query.single().unwrap();
-                commands
-                    .entity(window)
-                    .insert(CursorIcon::System(SystemCursorIcon::Pointer));
-            },
-        )
-        .observe(
-            |_trigger: On<Pointer<Out>>,
-             window_query: Query<Entity, With<Window>>,
-             mut commands: Commands| {
-                let window = window_query.single().unwrap();
-                commands
-                    .entity(window)
-                    .insert(CursorIcon::System(SystemCursorIcon::Default));
-            },
-        )
         .with_children(|parent| {
             parent
                 .spawn(Node {
@@ -201,6 +182,10 @@ pub(crate) fn spawn_resize_handle<'a>(
         ZIndex(3),
     ));
     // Add the Resize
+    let cursor_icon = match divider_parent {
+        Divider::Horizontal => SystemCursorIcon::EwResize,
+        Divider::Vertical => SystemCursorIcon::NsResize,
+    };
     ec.with_child((
         Node {
             width: match divider_parent {
@@ -214,6 +199,7 @@ pub(crate) fn spawn_resize_handle<'a>(
             ..default()
         },
         ResizeHandle,
+        EntityCursor::System(cursor_icon),
     ))
     .observe(
         move |trigger: On<Pointer<DragStart>>,
@@ -297,29 +283,6 @@ pub(crate) fn spawn_resize_handle<'a>(
         |_trigger: On<Pointer<Cancel>>, mut drag_state: ResMut<DragState>| {
             drag_state.is_dragging = false;
             drag_state.offset = 0.;
-        },
-    )
-    .observe(
-        move |_trigger: On<Pointer<Move>>,
-              window_query: Query<Entity, With<Window>>,
-              mut commands: Commands| {
-            let window = window_query.single().unwrap();
-            commands
-                .entity(window)
-                .insert(CursorIcon::System(match divider_parent {
-                    Divider::Horizontal => SystemCursorIcon::EwResize,
-                    Divider::Vertical => SystemCursorIcon::NsResize,
-                }));
-        },
-    )
-    .observe(
-        |_trigger: On<Pointer<Out>>,
-         window_query: Query<Entity, With<Window>>,
-         mut commands: Commands| {
-            let window = window_query.single().unwrap();
-            commands
-                .entity(window)
-                .insert(CursorIcon::System(SystemCursorIcon::Default));
         },
     );
     ec

--- a/crates/bevy_proto_bsn/src/bsn_asset.rs
+++ b/crates/bevy_proto_bsn/src/bsn_asset.rs
@@ -321,13 +321,13 @@ impl TryFrom<&ExprUnary> for BsnValue {
     type Error = BsnLoaderError;
 
     fn try_from(value: &ExprUnary) -> Result<Self, Self::Error> {
-        if let UnOp::Neg(_) = value.op {
-            if let Expr::Lit(lit) = value.expr.as_ref() {
-                let mut bsn_value: BsnValue = lit.into();
-                if let BsnValue::Number(ref mut f) = bsn_value {
-                    f.insert(0, '-');
-                    return Ok(bsn_value);
-                }
+        if let UnOp::Neg(_) = value.op
+            && let Expr::Lit(lit) = value.expr.as_ref()
+        {
+            let mut bsn_value: BsnValue = lit.into();
+            if let BsnValue::Number(ref mut f) = bsn_value {
+                f.insert(0, '-');
+                return Ok(bsn_value);
             }
         }
 

--- a/crates/bevy_proto_bsn/src/bsn_reflect.rs
+++ b/crates/bevy_proto_bsn/src/bsn_reflect.rs
@@ -362,22 +362,21 @@ impl<'a, 'b> BsnReflector<'a, 'b> {
     ) -> ReflectResult<Box<dyn PartialReflect>> {
         // HACK: Allows constructing Handles from asset paths in BSN assets by triggering loads during reflection.
         // This should be removed when we have an upstream Construct implementation for Handle.
-        if ty.type_path().starts_with("bevy_asset::handle::Handle<") && self.asset_loader.is_some()
+        if ty.type_path().starts_with("bevy_asset::handle::Handle<")
+            && self.asset_loader.is_some()
+            && let BsnProp::Props(BsnValue::String(asset_path)) = prop
         {
-            if let BsnProp::Props(BsnValue::String(asset_path)) = prop {
-                let Some(reflect_handle_load) = self
-                    .registry
-                    .get_type_data::<ReflectHandleLoad>(ty.type_id())
-                else {
-                    return Err(ReflectError::MissingTypeData(
-                        "ReflectHandleLoad".into(),
-                        ty.type_path().into(),
-                    ));
-                };
-                let handle =
-                    reflect_handle_load.load(asset_path, self.asset_loader.as_ref().unwrap());
-                return Ok(handle.into_partial_reflect());
-            }
+            let Some(reflect_handle_load) = self
+                .registry
+                .get_type_data::<ReflectHandleLoad>(ty.type_id())
+            else {
+                return Err(ReflectError::MissingTypeData(
+                    "ReflectHandleLoad".into(),
+                    ty.type_path().into(),
+                ));
+            };
+            let handle = reflect_handle_load.load(asset_path, self.asset_loader.as_ref().unwrap());
+            return Ok(handle.into_partial_reflect());
         }
 
         // This is fine : )

--- a/crates/bevy_proto_bsn/src/construct.rs
+++ b/crates/bevy_proto_bsn/src/construct.rs
@@ -130,13 +130,16 @@ impl<'a> ConstructContext<'a> {
 /// Construct extension
 pub trait ConstructEntityCommandsExt {
     /// Construct a bundle using the given props and insert it onto the entity.
-    fn construct<T: Construct + Bundle>(&mut self, props: impl Into<T::Props>) -> EntityCommands
+    fn construct<T: Construct + Bundle>(
+        &mut self,
+        props: impl Into<T::Props>,
+    ) -> EntityCommands<'_>
     where
         <T as Construct>::Props: Send;
 }
 
 impl ConstructEntityCommandsExt for EntityCommands<'_> {
-    fn construct<T: Construct + Bundle>(&mut self, props: impl Into<T::Props>) -> EntityCommands
+    fn construct<T: Construct + Bundle>(&mut self, props: impl Into<T::Props>) -> EntityCommands<'_>
     where
         <T as Construct>::Props: Send,
     {

--- a/crates/bevy_proto_bsn/src/entity_patch.rs
+++ b/crates/bevy_proto_bsn/src/entity_patch.rs
@@ -221,12 +221,12 @@ where
 /// Extension trait implementing [`Scene`] utilities for [`EntityCommands`].
 pub trait EntityCommandsSceneExt {
     /// Constructs a [`Scene`] and applies it to the entity.
-    fn construct_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands;
+    fn construct_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands<'_>;
 }
 
 impl EntityCommandsSceneExt for EntityCommands<'_> {
     // type Out = EntityCommands;
-    fn construct_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands {
+    fn construct_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands<'_> {
         self.queue(ConstructSceneCommand(scene));
         self.reborrow()
     }
@@ -235,12 +235,12 @@ impl EntityCommandsSceneExt for EntityCommands<'_> {
 /// Scene spawning extension.
 pub trait SpawnSceneExt {
     /// Spawn the given [`Scene`].
-    fn spawn_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands;
+    fn spawn_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands<'_>;
 }
 
 impl SpawnSceneExt for Commands<'_, '_> {
     /// Spawn the given [`Scene`].
-    fn spawn_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands {
+    fn spawn_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands<'_> {
         let mut entity = self.spawn_empty();
         entity.queue(ConstructSceneCommand(scene));
         entity
@@ -248,7 +248,7 @@ impl SpawnSceneExt for Commands<'_, '_> {
 }
 
 impl SpawnSceneExt for ChildSpawnerCommands<'_> {
-    fn spawn_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands {
+    fn spawn_scene(&mut self, scene: impl Scene + Send + 'static) -> EntityCommands<'_> {
         let mut entity = self.spawn_empty();
         entity.queue(ConstructSceneCommand(scene));
         entity

--- a/crates/bevy_undo/src/lib.rs
+++ b/crates/bevy_undo/src/lib.rs
@@ -1407,15 +1407,15 @@ fn auto_undo_remove_detect<T: Component + Clone>(
     ignore_storage: ResMut<UndoIgnoreStorage>,
 ) {
     for e in removed_query.read() {
-        if !ignore_storage.storage.contains_key(&e) {
-            if let Some(prev_value) = storage.storage.remove(&e) {
-                new_changes.write(NewChange {
-                    change: Arc::new(RemovedComponent {
-                        old_value: prev_value,
-                        entity: e,
-                    }),
-                });
-            }
+        if !ignore_storage.storage.contains_key(&e)
+            && let Some(prev_value) = storage.storage.remove(&e)
+        {
+            new_changes.write(NewChange {
+                change: Arc::new(RemovedComponent {
+                    old_value: prev_value,
+                    entity: e,
+                }),
+            });
         }
     }
 }
@@ -1428,15 +1428,15 @@ fn auto_undo_reflected_remove_detect<T: Component + Reflect + FromReflect>(
     ignore_storage: ResMut<UndoIgnoreStorage>,
 ) {
     for e in removed_query.read() {
-        if !ignore_storage.storage.contains_key(&e) {
-            if let Some(prev_value) = storage.storage.remove(&e) {
-                new_changes.write(NewChange {
-                    change: Arc::new(ReflectedRemovedComponent {
-                        old_value: prev_value,
-                        entity: e,
-                    }),
-                });
-            }
+        if !ignore_storage.storage.contains_key(&e)
+            && let Some(prev_value) = storage.storage.remove(&e)
+        {
+            new_changes.write(NewChange {
+                change: Arc::new(ReflectedRemovedComponent {
+                    old_value: prev_value,
+                    entity: e,
+                }),
+            });
         }
     }
 }


### PR DESCRIPTION
Some bugs have been stalling my work on the experiments here. ~~I'd like to bring in some fixes ahead of cart updating the PR branch. I suspect he is kept busy with release prep work for Bevy 0.17~~
edit: Cart has taken the time to update his branch :)

- This PR updates our bevy dependency ~~ahead of cart's PR~~ to bring in [this bugfix](https://github.com/cart/bevy/pull/42) and a [merge with main](https://github.com/cart/bevy/pull/43) to get several UI node bugfixes.
- Removed the `.insert(Node::default())` workaround on BSN scene spawns. They're no longer necessary.
- Unrelated to the update, but since https://github.com/bevyengine/bevy/pull/20427 required me to update the import paths I just took the time to remove the old mouse icon code and use the `EntityCursor` component instead
- Fix the new lints for Rust 1.89
- Reduce the amount of debug info generated in CI to line tables only.