### PR TITLE
Prevent crash due to malformed heirarchy

### DIFF
--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -13,7 +13,7 @@ use bevy::{
         render_resource::{Extent3d, TextureFormat, TextureUsages},
         view::RenderLayers,
     },
-    scene2::{CommandsSpawnScene, ScenePatchInstance, bsn, on},
+    scene2::{CommandsSpawnScene, bsn, on},
     ui::ui_layout_system,
 };
 use bevy_editor_cam::prelude::{DefaultEditorCamPlugins, EditorCam};

--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -13,7 +13,7 @@ use bevy::{
         render_resource::{Extent3d, TextureFormat, TextureUsages},
         view::RenderLayers,
     },
-    scene2::{CommandsSpawnScene, bsn, on},
+    scene2::{CommandsSpawnScene, ScenePatchInstance, bsn, on},
     ui::ui_layout_system,
 };
 use bevy_editor_cam::prelude::{DefaultEditorCamPlugins, EditorCam};
@@ -118,10 +118,12 @@ fn render_target_picking_passthrough(
             continue;
         }
         for (pane_root, _viewport) in &viewports {
-            let content_node_id = children_query
+            let Some(content_node_id) = children_query
                 .iter_descendants(pane_root)
                 .find(|e| content.contains(*e))
-                .unwrap();
+            else {
+                continue;
+            };
 
             let image_id = children_query.get(content_node_id).unwrap()[0];
             let Ok((computed_node, global_transform, ui_image)) = node_query.get(image_id) else {


### PR DESCRIPTION
Fixes #249.

Removed the unwrap from `update_render_target_size` to prevent a crash due to the fact that the editor panes are spawned with bsn which is deferred.

This may not be desired it will ignore all non-bsn related hierarchy mistakes, but the only other alternative I can think of is reworking `on_pane_creation` to not use bsn which would be quite painful.