### PR TITLE
Upgrade to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,14 +27,10 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/cart/bevy.git", rev = "05b79c229a070224c007994e5c2be8b67439d7d9", features = [
-    "wayland",
-    "experimental_bevy_feathers",
-] }
-bevy_render = { git = "https://github.com/cart/bevy.git", rev = "05b79c229a070224c007994e5c2be8b67439d7d9" }
-bevy_derive = { git = "https://github.com/cart/bevy.git", rev = "05b79c229a070224c007994e5c2be8b67439d7d9" }
-bevy_macro_utils = { git = "https://github.com/cart/bevy.git", rev = "05b79c229a070224c007994e5c2be8b67439d7d9" }
-thiserror = "2.0"
+bevy = { version = "0.17", features = ["experimental_bevy_feathers"] }
+bevy_derive = "0.17"
+bevy_macro_utils = "0.17"
+thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 tracing-test = "0.2.5"
 tracing = "0.1.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-bevy = { version = "0.17", features = ["experimental_bevy_feathers"] }
-bevy_derive = "0.17"
-bevy_macro_utils = "0.17"
+bevy = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes", features = ["experimental_bevy_feathers"] }
+bevy_derive = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes" }
+bevy_macro_utils = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes" }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 tracing-test = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,16 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes-0.17.1", features = ["experimental_bevy_feathers"] }
-bevy_derive = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes-0.17.1" }
-bevy_macro_utils = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes-0.17.1" }
+bevy = { git = "https://github.com/cart/bevy.git", rev = "87a21ecafa51bfaea02834b5933f08397b45b984", features = ["experimental_bevy_feathers"] }
+bevy_derive = { git = "https://github.com/cart/bevy.git", rev = "87a21ecafa51bfaea02834b5933f08397b45b984" }
+bevy_macro_utils = { git = "https://github.com/cart/bevy.git", rev = "87a21ecafa51bfaea02834b5933f08397b45b984" }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 tracing-test = "0.2.5"
 tracing = "0.1.41"
 atomicow = "1.1.0"
-rfd = "0.15.3"
-ron = "0.10.1"
+rfd = "0.17.2"
+ron = "0.12.0"
 variadics_please = "1.0"
 
 # local crates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ unsafe_op_in_unsafe_fn = "warn"
 unused_qualifications = "warn"
 
 [workspace.dependencies]
-bevy = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes", features = ["experimental_bevy_feathers"] }
-bevy_derive = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes" }
-bevy_macro_utils = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes" }
+bevy = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes-0.17.1", features = ["experimental_bevy_feathers"] }
+bevy_derive = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes-0.17.1" }
+bevy_macro_utils = { git = "https://github.com/cart/bevy.git", branch = "next-gen-scenes-0.17.1" }
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 tracing-test = "0.2.5"

--- a/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
@@ -47,7 +47,7 @@ impl Plugin for Viewport2dPanePlugin {
                  query: Query<&Bevy2dViewport>| {
                     // Despawn the viewport camera
                     commands
-                        .entity(query.get(trigger.target()).unwrap().camera_id)
+                        .entity(query.get(trigger.event().event_target()).unwrap().camera_id)
                         .despawn();
                 },
             );

--- a/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_2d_viewport/src/lib.rs
@@ -1,12 +1,9 @@
 //! 2d Viewport for Bevy
 use bevy::{
+    camera::{RenderTarget, visibility::RenderLayers},
     feathers::theme::ThemedText,
     prelude::*,
-    render::{
-        camera::RenderTarget,
-        render_resource::{Extent3d, TextureFormat, TextureUsages},
-        view::RenderLayers,
-    },
+    render::render_resource::{Extent3d, TextureFormat, TextureUsages},
     scene2::{CommandsSpawnScene, bsn, on},
     ui::ui_layout_system,
 };

--- a/bevy_editor_panes/bevy_3d_viewport/Cargo.toml
+++ b/bevy_editor_panes/bevy_3d_viewport/Cargo.toml
@@ -10,7 +10,6 @@ bevy_editor_cam.workspace = true
 bevy_editor_styles.workspace = true
 bevy_infinite_grid.workspace = true
 bevy_editor_core.workspace = true
-bevy_render.workspace = true
 bevy_transform_gizmos.workspace = true
 
 [lints]

--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -105,8 +105,8 @@ fn render_target_picking_passthrough(
     content: Query<&PaneContentNode>,
     children_query: Query<&Children>,
     node_query: Query<(&ComputedNode, &UiGlobalTransform, &ImageNode), With<Active>>,
-    mut pointer_input_reader: EventReader<PointerInput>,
-    // Using commands to output PointerInput events to avoid clashing with the EventReader
+    mut pointer_input_reader: MessageReader<PointerInput>,
+    // Using commands to output PointerInput events to avoid clashing with the MessageReader
     mut commands: Commands,
 ) {
     for event in pointer_input_reader.read() {

--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -1,6 +1,7 @@
 //! 3D Viewport for Bevy
 use bevy::{
     asset::uuid::Uuid,
+    camera::{NormalizedRenderTarget, RenderTarget, visibility::RenderLayers},
     feathers::theme::ThemedText,
     picking::{
         PickingSystems,
@@ -8,11 +9,7 @@ use bevy::{
         pointer::{Location, PointerId, PointerInput},
     },
     prelude::*,
-    render::{
-        camera::{NormalizedRenderTarget, RenderTarget},
-        render_resource::{Extent3d, TextureFormat, TextureUsages},
-        view::RenderLayers,
-    },
+    render::render_resource::{Extent3d, TextureFormat, TextureUsages},
     scene2::{CommandsSpawnScene, bsn, on},
     ui::ui_layout_system,
 };
@@ -140,7 +137,7 @@ fn render_target_picking_passthrough(
                 pointer_id: pointer_id_from_entity(pane_root),
             };
 
-            commands.write_event(event_copy);
+            commands.write_message(event_copy);
         }
     }
 }

--- a/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/lib.rs
@@ -71,7 +71,7 @@ impl Plugin for Viewport3dPanePlugin {
                  query: Query<&Bevy3dViewport>| {
                     // Despawn the viewport camera
                     commands
-                        .entity(query.get(trigger.target()).unwrap().camera_id)
+                        .entity(query.get(trigger.event().event_target()).unwrap().camera_id)
                         .despawn();
                 },
             );
@@ -193,10 +193,10 @@ fn on_pane_creation(
                     ImageNode::new(image.clone())
                     :fit_to_parent
                     on(|trigger: On<Pointer<Over>>, mut commands: Commands| {
-                        commands.entity(trigger.target()).insert(Active);
+                        commands.entity(trigger.event().event_target()).insert(Active);
                     })
                     on(|trigger: On<Pointer<Out>>, mut commands: Commands| {
-                        commands.entity(trigger.target()).remove::<Active>();
+                        commands.entity(trigger.event().event_target()).remove::<Active>();
                     })
                     [ :view_gizmo_node ]
                 ],

--- a/bevy_editor_panes/bevy_3d_viewport/src/selection_box.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/selection_box.rs
@@ -1,7 +1,7 @@
+use bevy::camera::primitives::Aabb;
 use bevy::ecs::system::SystemParam;
 use bevy::prelude::*;
 use bevy_editor_core::selection::EditorSelection;
-use bevy_render::primitives::Aabb;
 
 #[derive(SystemParam)]
 pub struct SelectionBoxQueries<'w, 's> {

--- a/bevy_editor_panes/bevy_3d_viewport/src/view_gizmo.rs
+++ b/bevy_editor_panes/bevy_3d_viewport/src/view_gizmo.rs
@@ -4,12 +4,10 @@
 
 use bevy::{
     asset::RenderAssetUsages,
+    camera::visibility::RenderLayers,
     ecs::template::template,
     prelude::*,
-    render::{
-        render_resource::{Extent3d, Face, TextureDimension, TextureFormat, TextureUsages},
-        view::RenderLayers,
-    },
+    render::render_resource::{Extent3d, Face, TextureDimension, TextureFormat, TextureUsages},
     scene2::{Scene, bsn},
 };
 use bevy_editor_cam::prelude::EditorCam;
@@ -44,7 +42,7 @@ pub fn view_gizmo_node() -> impl Scene {
             width: Val::Px({VIEW_GIZMO_TEXTURE_SIZE as f32}),
             height: Val::Px({VIEW_GIZMO_TEXTURE_SIZE as f32}),
         }
-        template(view_gizmo_template)
+        template(|c| view_gizmo_template(c.entity))
     }
 }
 

--- a/bevy_editor_panes/bevy_asset_browser/src/ui/nodes.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/ui/nodes.rs
@@ -34,7 +34,7 @@ pub(crate) fn spawn_source_node<'a>(
                 if trigger.event().button != PointerButton::Primary {
                     return;
                 }
-                let button = trigger.target();
+                let button = trigger.event().event_target();
                 let button_children = query_children.get(button).unwrap();
                 let source_name = &query_text
                     .get(button_children[1])
@@ -99,7 +99,7 @@ pub(crate) fn spawn_folder_node<'a>(
                 if trigger.event().button != PointerButton::Primary {
                     return;
                 }
-                let button = trigger.target();
+                let button = trigger.event().event_target();
                 let button_children = query_children.get(button).unwrap();
                 let folder_name = &query_text
                     .get(button_children[1])

--- a/bevy_editor_panes/bevy_asset_browser/src/ui/top_bar.rs
+++ b/bevy_editor_panes/bevy_asset_browser/src/ui/top_bar.rs
@@ -150,7 +150,7 @@ fn spawn_path_segment_ui<'a>(
                   mut location: ResMut<AssetBrowserLocation>,
                   query_children: Query<&Children>,
                   query_segment_info: Query<(&ChildOf, &LocationSegmentType)>| {
-                let segment = trigger.target();
+                let segment = trigger.event().event_target();
                 let (parent, segment_type) = query_segment_info.get(segment).unwrap();
                 match segment_type {
                     LocationSegmentType::Root => {

--- a/bevy_widgets/bevy_context_menu/src/lib.rs
+++ b/bevy_widgets/bevy_context_menu/src/lib.rs
@@ -26,7 +26,7 @@ fn on_secondary_button_down_entity_with_context_menu(
         return;
     }
 
-    let target = trigger.target();
+    let target = trigger.event().event_target();
     let Ok(menu) = query.get(target) else {
         return;
     };
@@ -46,7 +46,7 @@ fn on_secondary_button_down_entity_with_context_menu(
             ZIndex(10),
         ))
         .observe(|trigger: On<Pointer<Press>>, mut commands: Commands| {
-            commands.entity(trigger.target()).despawn();
+            commands.entity(trigger.event().event_target()).despawn();
         })
         .id();
 

--- a/bevy_widgets/bevy_context_menu/src/ui.rs
+++ b/bevy_widgets/bevy_context_menu/src/ui.rs
@@ -61,12 +61,13 @@ pub(crate) fn spawn_option<'a>(
             |trigger: On<Pointer<Over>>,
              theme: Res<Theme>,
              mut query: Query<&mut BackgroundColor>| {
-                *query.get_mut(trigger.target()).unwrap() = theme.context_menu.hover_color;
+                *query.get_mut(trigger.event().event_target()).unwrap() =
+                    theme.context_menu.hover_color;
             },
         )
         .observe(
             |trigger: On<Pointer<Out>>, mut query: Query<&mut BackgroundColor>| {
-                query.get_mut(trigger.target()).unwrap().0 = Color::NONE;
+                query.get_mut(trigger.event().event_target()).unwrap().0 = Color::NONE;
             },
         )
         .observe(
@@ -79,7 +80,7 @@ pub(crate) fn spawn_option<'a>(
                 }
                 // Despawn the context menu when an option is selected
                 let root = child_of_query
-                    .iter_ancestors(trigger.target())
+                    .iter_ancestors(trigger.event().event_target())
                     .last()
                     .unwrap();
                 commands.entity(root).despawn();

--- a/bevy_widgets/bevy_field_forms/examples/nickname.rs
+++ b/bevy_widgets/bevy_field_forms/examples/nickname.rs
@@ -103,12 +103,12 @@ fn on_validation_changed(
     mut commands: Commands,
     q_character_validator: Query<&CharacterValidator>,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
     let Ok(character_validator) = q_character_validator.get(entity) else {
         return;
     };
 
-    match &trigger.0 {
+    match &trigger.state {
         ValidationState::Valid | ValidationState::Unchecked => {
             commands
                 .entity(character_validator.msg_text)

--- a/bevy_widgets/bevy_field_forms/src/drag_input.rs
+++ b/bevy_widgets/bevy_field_forms/src/drag_input.rs
@@ -73,7 +73,7 @@ fn on_drag<T: Draggable>(
     mut commands: Commands,
     mut q_drag_inputs: Query<(&mut DragInput<T>, &mut InputField<T>)>,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
 
     let Ok((mut drag_input, mut input_field)) = q_drag_inputs.get_mut(entity) else {
         return;
@@ -94,7 +94,10 @@ fn on_drag<T: Draggable>(
             drag_input.drag_accumulate += accumulated_decrease;
         }
 
-        commands.trigger_targets(ValueChanged(new_val), entity);
+        commands.trigger(ValueChanged {
+            entity,
+            value: new_val,
+        });
         if !input_field.controlled {
             input_field.value = new_val;
         }

--- a/bevy_widgets/bevy_field_forms/src/input_field.rs
+++ b/bevy_widgets/bevy_field_forms/src/input_field.rs
@@ -102,21 +102,27 @@ pub enum ValidationState {
 /// Event that is emitted when the validation state changes
 #[derive(EntityEvent)]
 pub struct ValidationChanged {
+    /// The target entity.
     pub entity: Entity,
+    /// The new validation state.
     pub state: ValidationState,
 }
 
 /// Event that is emitted when the value changes
 #[derive(EntityEvent)]
 pub struct ValueChanged<T: Validable> {
+    /// The target entity.
     pub entity: Entity,
+    /// The value updated.
     pub value: T,
 }
 
 /// This event is used to set the value of the validated input field.
 #[derive(EntityEvent)]
 pub struct SetValue<T: Validable> {
+    /// The target entity.
     pub entity: Entity,
+    /// The value set.
     pub value: T,
 }
 

--- a/bevy_widgets/bevy_field_forms/src/input_field.rs
+++ b/bevy_widgets/bevy_field_forms/src/input_field.rs
@@ -101,22 +101,31 @@ pub enum ValidationState {
 
 /// Event that is emitted when the validation state changes
 #[derive(EntityEvent)]
-pub struct ValidationChanged(pub ValidationState);
+pub struct ValidationChanged {
+    pub entity: Entity,
+    pub state: ValidationState,
+}
 
 /// Event that is emitted when the value changes
 #[derive(EntityEvent)]
-pub struct ValueChanged<T: Validable>(pub T);
+pub struct ValueChanged<T: Validable> {
+    pub entity: Entity,
+    pub value: T,
+}
 
 /// This event is used to set the value of the validated input field.
 #[derive(EntityEvent)]
-pub struct SetValue<T: Validable>(pub T);
+pub struct SetValue<T: Validable> {
+    pub entity: Entity,
+    pub value: T,
+}
 
 fn on_text_changed<T: Validable>(
     mut trigger: On<TextChanged>,
     mut commands: Commands,
     mut q_validated_input_fields: Query<&mut InputField<T>>,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
     let Ok(mut field) = q_validated_input_fields.get_mut(entity) else {
         return;
     };
@@ -126,10 +135,19 @@ fn on_text_changed<T: Validable>(
 
     match T::validate(&new_text) {
         Ok(value) => {
-            commands.trigger_targets(ValueChanged(value.clone()), entity);
-            commands.trigger_targets(ValidationChanged(ValidationState::Valid), entity);
+            commands.trigger(ValueChanged {
+                entity,
+                value: value.clone(),
+            });
+            commands.trigger(ValidationChanged {
+                entity,
+                state: ValidationState::Valid,
+            });
             // As editable label is controlled, we need to set the text manually
-            commands.trigger_targets(SetText(new_text), entity);
+            commands.trigger(SetText {
+                entity,
+                text: new_text,
+            });
             // Update the value only if the field is not controlled
             if !field.controlled {
                 // Update the text in the EditableTextLine
@@ -139,8 +157,14 @@ fn on_text_changed<T: Validable>(
         }
         Err(error) => {
             // As editable label is controlled, we need to set the text manually
-            commands.trigger_targets(SetText(new_text), entity);
-            commands.trigger_targets(ValidationChanged(ValidationState::Invalid(error)), entity);
+            commands.trigger(SetText {
+                entity,
+                text: new_text,
+            });
+            commands.trigger(ValidationChanged {
+                entity,
+                state: ValidationState::Invalid(error),
+            });
         }
     }
 }
@@ -156,8 +180,14 @@ fn on_value_changed<T: Validable>(
 
             // We will not trigger ValueChanged because it must be triggered only by input change
             // If value field was changed by external code, we will not trigger it again
-            commands.trigger_targets(SetText(field.value.to_string()), entity);
-            commands.trigger_targets(ValidationChanged(ValidationState::Valid), entity);
+            commands.trigger(SetText {
+                entity,
+                text: field.value.to_string(),
+            });
+            commands.trigger(ValidationChanged {
+                entity,
+                state: ValidationState::Valid,
+            });
         }
     }
 }
@@ -168,8 +198,14 @@ fn on_created<T: Validable>(
 ) {
     for (entity, field) in q_created_inputs.iter() {
         // Set start state
-        commands.trigger_targets(SetText(field.value.to_string()), entity);
-        commands.trigger_targets(ValidationChanged(ValidationState::Valid), entity);
+        commands.trigger(SetText {
+            entity,
+            text: field.value.to_string(),
+        });
+        commands.trigger(ValidationChanged {
+            entity,
+            state: ValidationState::Valid,
+        });
     }
 }
 

--- a/bevy_widgets/bevy_field_forms/src/text_event_mirror.rs
+++ b/bevy_widgets/bevy_field_forms/src/text_event_mirror.rs
@@ -25,7 +25,7 @@ fn on_text_changed(
     mut commands: Commands,
     q_mirrors: Query<Entity, With<TextEventMirror>>,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
     let Ok(_) = q_mirrors.get(entity) else {
         return;
     };
@@ -34,5 +34,8 @@ fn on_text_changed(
 
     info!("Text mirrored with value {:?}", trigger.new_text);
 
-    commands.trigger_targets(SetText(trigger.new_text.clone()), entity);
+    commands.trigger(SetText {
+        entity,
+        text: trigger.new_text.clone(),
+    });
 }

--- a/bevy_widgets/bevy_field_forms/src/validate_highlight.rs
+++ b/bevy_widgets/bevy_field_forms/src/validate_highlight.rs
@@ -49,12 +49,12 @@ fn on_validation_changed(
     mut commands: Commands,
     mut q_highlights: Query<(&mut SimpleBorderHighlight, &Interaction, &HasFocus)>,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
     let Ok((mut highlight, interaction, has_focus)) = q_highlights.get_mut(entity) else {
         return;
     };
 
-    match &trigger.0 {
+    match &trigger.state {
         ValidationState::Valid | ValidationState::Unchecked => {
             if has_focus.0 {
                 commands
@@ -77,7 +77,7 @@ fn on_validation_changed(
         }
     }
 
-    highlight.last_validation_state = trigger.0.clone();
+    highlight.last_validation_state = trigger.state.clone();
 }
 
 fn on_focus_changed(
@@ -85,15 +85,15 @@ fn on_focus_changed(
     q_highlights: Query<&SimpleBorderHighlight>,
     mut commands: Commands,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
     let Ok(highlight) = q_highlights.get(entity) else {
         return;
     };
 
-    commands.trigger_targets(
-        ValidationChanged(highlight.last_validation_state.clone()),
+    commands.trigger(ValidationChanged {
         entity,
-    );
+        state: highlight.last_validation_state.clone(),
+    });
 }
 
 fn on_interaction_changed(
@@ -101,9 +101,9 @@ fn on_interaction_changed(
     q_changed_interaction: Query<(Entity, &SimpleBorderHighlight), Changed<Interaction>>,
 ) {
     for (entity, highlight) in q_changed_interaction.iter() {
-        commands.trigger_targets(
-            ValidationChanged(highlight.last_validation_state.clone()),
+        commands.trigger(ValidationChanged {
             entity,
-        );
+            state: highlight.last_validation_state.clone(),
+        });
     }
 }

--- a/bevy_widgets/bevy_menu_bar/src/lib.rs
+++ b/bevy_widgets/bevy_menu_bar/src/lib.rs
@@ -71,19 +71,19 @@ fn menu_setup(
 
     let mut hover_over_observer = Observer::new(
         |trigger: On<Pointer<Over>>, theme: Res<Theme>, mut query: Query<&mut BackgroundColor>| {
-            query.get_mut(trigger.target()).unwrap().0 = theme.button.hover_color;
+            query.get_mut(trigger.event().event_target()).unwrap().0 = theme.button.hover_color;
         },
     );
     let mut hover_out_observer = Observer::new(
         |trigger: On<Pointer<Out>>, theme: Res<Theme>, mut query: Query<&mut BackgroundColor>| {
-            query.get_mut(trigger.target()).unwrap().0 = theme.menu.background_color;
+            query.get_mut(trigger.event().event_target()).unwrap().0 = theme.menu.background_color;
         },
     );
 
     let mut click_observer = Observer::new(
         |trigger: On<Pointer<Press>>, mut query: Query<&TopBarItem>| {
             #[allow(clippy::match_same_arms)]
-            match query.get_mut(trigger.target()).unwrap() {
+            match query.get_mut(trigger.event().event_target()).unwrap() {
                 TopBarItem::Logo => {
                     // TODO: Implement logo click action
                 }

--- a/bevy_widgets/bevy_scroll_box/src/lib.rs
+++ b/bevy_widgets/bevy_scroll_box/src/lib.rs
@@ -177,7 +177,7 @@ fn spawn_scroll_bar<'a>(
              mut query_scrollbox: Query<(&mut ScrollBox, &RelativeCursorPosition, &Children)>,
              query_computed_node: Query<&ComputedNode>,
              mut query_node: Query<&mut Node>| {
-                let handle_entity = trigger.target();
+                let handle_entity = trigger.event().event_target();
                 let handle = query_handle.get(handle_entity).unwrap();
                 let scrollbox_entity = {
                     let scrollbar_parent = query_parent.get(handle_entity).unwrap();

--- a/bevy_widgets/bevy_scroll_box/src/lib.rs
+++ b/bevy_widgets/bevy_scroll_box/src/lib.rs
@@ -235,7 +235,7 @@ fn spawn_scroll_bar<'a>(
 }
 
 fn on_scroll(
-    mut mouse_wheel_events: EventReader<MouseWheel>,
+    mut mouse_wheel_events: MessageReader<MouseWheel>,
     mut query_scrollbox: Query<(&RelativeCursorPosition, Entity, &mut ScrollBox, &Children)>,
     query_scrollbox_content: Query<&ComputedNode, With<ScrollBoxContent>>,
     query_computed_node: Query<&ComputedNode>,

--- a/bevy_widgets/bevy_text_editing/examples/password.rs
+++ b/bevy_widgets/bevy_text_editing/examples/password.rs
@@ -73,7 +73,7 @@ fn update_password(
     mut commands: Commands,
     mut q_passwords: Query<&mut Password>,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
     let Ok(mut password) = q_passwords.get_mut(entity) else {
         return;
     };
@@ -85,7 +85,10 @@ fn update_password(
     info!("Password: {:?}", password.val);
 
     let asterisks = "*".repeat(password.val.chars().count());
-    commands.trigger_targets(SetText(asterisks), entity);
+    commands.trigger(SetText {
+        entity,
+        text: asterisks,
+    });
 }
 
 fn show_password(

--- a/bevy_widgets/bevy_text_editing/src/char_position.rs
+++ b/bevy_widgets/bevy_text_editing/src/char_position.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 /// A component that stores a character position in a text
 /// Separated from `usize` to make it clear that it is a character position, not a byte position.
-/// And prevents accidental usage as a byte position in string[..`byte_position`]
+/// And prevents accidental usage as a byte position in `string[..byte_position]`
 #[derive(Reflect, Default, Clone, Copy, Debug)]
 pub struct CharPosition(pub usize);
 

--- a/bevy_widgets/bevy_text_editing/src/editable_text_line.rs
+++ b/bevy_widgets/bevy_text_editing/src/editable_text_line.rs
@@ -236,16 +236,29 @@ pub struct EditableTextInner {
 }
 
 /// Event for rendering editable text line
-#[derive(EntityEvent, Default, Clone)]
+#[derive(Clone, EntityEvent)]
 pub struct RenderWidget {
+    /// The entity to propagate to
+    pub entity: Entity,
     /// Make cursor immediately visible and reset cursor blinking timer
     pub show_cursor: bool,
 }
 
 impl RenderWidget {
+    /// Make cursor immediately invisible and reset cursor blinking timer
+    pub fn hide_cursor(entity: Entity) -> Self {
+        Self {
+            entity,
+            show_cursor: false,
+        }
+    }
+
     /// Make cursor immediately visible and reset cursor blinking timer
-    pub fn show_cursor() -> Self {
-        Self { show_cursor: true }
+    pub fn show_cursor(entity: Entity) -> Self {
+        Self {
+            entity,
+            show_cursor: true,
+        }
     }
 }
 
@@ -392,16 +405,16 @@ fn set_text_trigger(
     mut commands: Commands,
     mut q_texts: Query<&mut EditableTextLine>,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
     let Ok(mut line) = q_texts.get_mut(entity) else {
         return;
     };
 
-    line.text = trigger.0.clone();
-    // info!("Set text for {} to {}", entity, trigger.0);
+    line.text = trigger.text.clone();
+    // info!("Set text for {} to {}", entity, trigger.text);
 
     // Trigger rerender
-    commands.trigger_targets(RenderWidget::default(), entity);
+    commands.trigger(RenderWidget::hide_cursor(entity));
 }
 
 fn propagate_text_font(

--- a/bevy_widgets/bevy_text_editing/src/editable_text_line/input.rs
+++ b/bevy_widgets/bevy_text_editing/src/editable_text_line/input.rs
@@ -51,7 +51,7 @@ pub fn on_click(
     text_line.cursor_position = Some(CharPosition(cursor_pos));
     inner.skip_cursor_overflow_check = true;
 
-    commands.trigger_targets(RenderWidget::show_cursor(), entity);
+    commands.trigger(RenderWidget::show_cursor(entity));
 }
 
 pub fn on_key_input(
@@ -230,21 +230,19 @@ pub fn on_key_input(
     let old_cursor_position = text_field.cursor_position;
     // cursor position changed hided in if to pervert infinite change triggering
     text_field.cursor_position = Some(current_cursor);
-    commands.trigger_targets(RenderWidget::show_cursor(), entity);
+    commands.trigger(RenderWidget::show_cursor(entity));
 
     if text_field.text != text_change.new_text {
         // Send the text change event with the new text
         let mut new_text = text_field.text.clone();
         text_change.apply(&mut new_text);
-        commands.trigger_targets(
-            TextChanged {
-                change: text_change.clone(),
-                new_text,
-                old_cursor_position,
-                new_cursor_position: Some(current_cursor),
-            },
+        commands.trigger(TextChanged {
             entity,
-        );
+            change: text_change.clone(),
+            new_text,
+            old_cursor_position,
+            new_cursor_position: Some(current_cursor),
+        });
 
         // If the text field is not controlled, apply the text change to the text field
         if !text_field.controlled_widget {
@@ -273,7 +271,7 @@ pub fn update_has_focus(
                     && text_field.cursor_position.is_none()
                 {
                     text_field.cursor_position = Some(CharPosition(0));
-                    commands.trigger_targets(RenderWidget::show_cursor(), entity);
+                    commands.trigger(RenderWidget::show_cursor(entity));
                 }
             }
         } else if has_focus.0 {
@@ -285,7 +283,7 @@ pub fn update_has_focus(
                 text_field.cursor_position = None;
                 text_field.selection_start = None;
 
-                commands.trigger_targets(RenderWidget::default(), entity);
+                commands.trigger(RenderWidget::hide_cursor(entity));
             }
         }
     }
@@ -296,11 +294,11 @@ pub fn on_set_cursor_position(
     mut commands: Commands,
     mut q_editable_texts: Query<&mut EditableTextLine>,
 ) {
-    let entity = trigger.target();
+    let entity = trigger.event().event_target();
     let Ok(mut text_field) = q_editable_texts.get_mut(entity) else {
         return;
     };
 
-    text_field.cursor_position = Some(trigger.0);
-    commands.trigger_targets(RenderWidget::show_cursor(), entity);
+    text_field.cursor_position = Some(trigger.position);
+    commands.trigger(RenderWidget::show_cursor(entity));
 }

--- a/bevy_widgets/bevy_text_editing/src/editable_text_line/input.rs
+++ b/bevy_widgets/bevy_text_editing/src/editable_text_line/input.rs
@@ -15,7 +15,7 @@ pub fn on_click(
     q_texts: Query<(&ComputedNode, &UiGlobalTransform)>,
     key_states: Res<ButtonInput<KeyCode>>,
 ) {
-    let entity = click.target();
+    let entity = click.event().event_target();
     let Ok((mut text_line, mut inner)) = q_editable_texts.get_mut(entity) else {
         return;
     };
@@ -67,7 +67,7 @@ pub fn on_key_input(
         return;
     }
 
-    let Ok((entity, mut text_field)) = q_text_fields.get_mut(trigger.target()) else {
+    let Ok((entity, mut text_field)) = q_text_fields.get_mut(trigger.event().event_target()) else {
         return;
     };
 

--- a/bevy_widgets/bevy_text_editing/src/editable_text_line/render.rs
+++ b/bevy_widgets/bevy_text_editing/src/editable_text_line/render.rs
@@ -156,7 +156,7 @@ pub(crate) fn check_cursor_overflow(
                     - text_field_node.size().x / 2.0
                     + padding;
                 canvas_node.left = Val::Px(-inner.text_shift);
-                commands.trigger_targets(RenderWidget::default(), entity);
+                commands.trigger(RenderWidget::hide_cursor(entity));
             } else if (cursor_transform.translation.x - text_field_transform.translation.x)
                 < -text_field_node.size().x / 2.0 + padding
             {
@@ -165,13 +165,13 @@ pub(crate) fn check_cursor_overflow(
                     + text_field_node.size().x / 2.0
                     - padding;
                 canvas_node.left = Val::Px(-inner.text_shift);
-                commands.trigger_targets(RenderWidget::default(), entity);
+                commands.trigger(RenderWidget::hide_cursor(entity));
             }
         } else if inner.text_shift != 0.0 {
             info!("Reset shift {:?}", entity);
             inner.text_shift = 0.0;
             canvas_node.left = Val::Px(0.0);
-            commands.trigger_targets(RenderWidget::default(), entity);
+            commands.trigger(RenderWidget::hide_cursor(entity));
         }
     }
 }

--- a/bevy_widgets/bevy_text_editing/src/lib.rs
+++ b/bevy_widgets/bevy_text_editing/src/lib.rs
@@ -20,17 +20,21 @@ pub const TEXT_SELECTION_COLOR: Color = Color::srgb(0.0 / 255.0, 122.0 / 255.0, 
 
 /// An event used to set the text of an editable text widget.
 /// Will be propagated to the first child of the entity it's sent to.
-#[derive(Clone, Component, Event)]
-pub struct SetText(pub String);
-
-impl EntityEvent for SetText {
-    type Traversal = &'static CachedFirstChild;
-    const AUTO_PROPAGATE: bool = true;
+#[derive(Clone, Component, EntityEvent)]
+#[entity_event(propagate = &'static CachedFirstChild)]
+pub struct SetText {
+    /// The first entity child to propagate to
+    pub entity: Entity,
+    /// The text to set
+    pub text: String,
 }
 
 /// Event emitted when the text in an editable text component changes
-#[derive(Clone, Component, Event)]
+#[derive(Clone, Component, EntityEvent)]
+#[entity_event(propagate, auto_propagate)]
 pub struct TextChanged {
+    /// The entity to propagate to
+    pub entity: Entity,
     /// The specific change that occurred to the text
     pub change: TextChange,
     /// The new text content after the change (can be not valid if editable text widget shows different from source-of-truth text)
@@ -41,20 +45,15 @@ pub struct TextChanged {
     pub new_cursor_position: Option<CharPosition>,
 }
 
-impl EntityEvent for TextChanged {
-    type Traversal = &'static ChildOf;
-
-    const AUTO_PROPAGATE: bool = true;
-}
-
 /// An event used to set the cursor position of an editable text widget.
 /// Will be propagated to the first child of the entity it's sent to.
-#[derive(Clone, Event, Component)]
-pub struct SetCursorPosition(pub CharPosition);
-
-impl EntityEvent for SetCursorPosition {
-    type Traversal = &'static CachedFirstChild;
-    const AUTO_PROPAGATE: bool = true;
+#[derive(Clone, Component, EntityEvent)]
+#[entity_event(propagate = &'static CachedFirstChild)]
+pub struct SetCursorPosition {
+    /// The first entity child to propagate to
+    pub entity: Entity,
+    /// The cursor position to set
+    pub position: CharPosition,
 }
 
 /// A component holding a boolean for whether an entity has focus.

--- a/bevy_widgets/bevy_toolbar/src/lib.rs
+++ b/bevy_widgets/bevy_toolbar/src/lib.rs
@@ -42,9 +42,10 @@ pub struct ToolbarButton {
 }
 
 /// Available editor tools.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum EditorTool {
     /// Selection tool for picking entities.
+    #[default]
     Select,
     /// Move tool for translating entities.
     Move,
@@ -73,12 +74,6 @@ pub enum EditorTool {
 /// Current active tool resource.
 #[derive(Resource, Default)]
 pub struct ActiveTool(pub EditorTool);
-
-impl Default for EditorTool {
-    fn default() -> Self {
-        Self::Select
-    }
-}
 
 /// Marker component for the gizmo mode status text.
 #[derive(Component)]

--- a/crates/bevy_editor/src/lib.rs
+++ b/crates/bevy_editor/src/lib.rs
@@ -19,9 +19,9 @@ use bevy::asset::UnapprovedPathMode;
 use bevy::color::palettes::tailwind;
 use bevy::prelude::*;
 use bevy::{
-    core_widgets::CoreWidgetsPlugins,
     feathers::{FeathersPlugin, dark_theme::create_dark_theme, theme::UiTheme},
     input_focus::{InputDispatchPlugin, tab_navigation::TabNavigationPlugin},
+    ui_widgets::UiWidgetsPlugins,
 };
 // Re-export Bevy for project use
 pub use bevy;
@@ -77,7 +77,7 @@ impl Plugin for EditorPlugin {
                 LoadGltfPlugin,
                 MeshPickingPlugin,
                 TransformGizmoPlugin,
-                CoreWidgetsPlugins,
+                UiWidgetsPlugins,
                 InputDispatchPlugin,
                 TabNavigationPlugin,
                 FeathersPlugin,

--- a/crates/bevy_editor/src/load_gltf.rs
+++ b/crates/bevy_editor/src/load_gltf.rs
@@ -21,7 +21,7 @@ impl Plugin for LoadGltfPlugin {
 fn file_dropped(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    mut event_reader: EventReader<FileDragAndDrop>,
+    mut event_reader: MessageReader<FileDragAndDrop>,
 ) {
     for event in event_reader.read() {
         if let FileDragAndDrop::DroppedFile { path_buf, .. } = event

--- a/crates/bevy_editor_cam/examples/cad.rs
+++ b/crates/bevy_editor_cam/examples/cad.rs
@@ -1,9 +1,9 @@
 //! Editor camera example with an expanded control scheme fit for CAD software.
 
 use bevy::{
-    anti_aliasing::taa::{TemporalAntiAliasPlugin, TemporalAntiAliasing},
-    core_pipeline::bloom::Bloom,
+    anti_alias::taa::{TemporalAntiAliasPlugin, TemporalAntiAliasing},
     pbr::ScreenSpaceAmbientOcclusion,
+    post_process::bloom::Bloom,
     prelude::*,
     render::camera::TemporalJitter,
 };

--- a/crates/bevy_editor_cam/examples/cad.rs
+++ b/crates/bevy_editor_cam/examples/cad.rs
@@ -87,7 +87,7 @@ fn projection_specific_render_config(
 
 fn toggle_projection(
     keys: Res<ButtonInput<KeyCode>>,
-    mut dolly: EventWriter<DollyZoomTrigger>,
+    mut dolly: MessageWriter<DollyZoomTrigger>,
     cam: Query<Entity, With<EditorCam>>,
     mut toggled: Local<bool>,
 ) {
@@ -108,7 +108,7 @@ fn toggle_projection(
 fn toggle_constraint(
     keys: Res<ButtonInput<KeyCode>>,
     mut cam: Query<(Entity, &Transform, &mut EditorCam)>,
-    mut look_to: EventWriter<LookToTrigger>,
+    mut look_to: MessageWriter<LookToTrigger>,
 ) {
     if keys.just_pressed(KeyCode::KeyC) {
         let (entity, transform, mut editor) = cam.single_mut().unwrap();
@@ -133,7 +133,7 @@ fn toggle_constraint(
 
 fn switch_direction(
     keys: Res<ButtonInput<KeyCode>>,
-    mut look_to: EventWriter<LookToTrigger>,
+    mut look_to: MessageWriter<LookToTrigger>,
     cam: Query<(Entity, &Transform, &EditorCam)>,
 ) {
     let (camera, transform, editor) = cam.single().unwrap();

--- a/crates/bevy_editor_cam/examples/map.rs
+++ b/crates/bevy_editor_cam/examples/map.rs
@@ -1,8 +1,8 @@
 //! Editor camera example with a city map to traverse.
 
 use bevy::{
-    anti_aliasing::taa::TemporalAntiAliasing, color::palettes, core_pipeline::bloom::Bloom,
-    pbr::ScreenSpaceAmbientOcclusion,
+    anti_alias::taa::TemporalAntiAliasing, color::palettes, pbr::ScreenSpaceAmbientOcclusion,
+    post_process::bloom::Bloom,
 };
 use bevy::{prelude::*, render::camera::TemporalJitter};
 use bevy_editor_cam::{extensions::dolly_zoom::DollyZoomTrigger, prelude::*};

--- a/crates/bevy_editor_cam/examples/map.rs
+++ b/crates/bevy_editor_cam/examples/map.rs
@@ -89,7 +89,7 @@ fn spawn_buildings(
 
 fn toggle_projection(
     keys: Res<ButtonInput<KeyCode>>,
-    mut dolly: EventWriter<DollyZoomTrigger>,
+    mut dolly: MessageWriter<DollyZoomTrigger>,
     cam: Query<Entity, With<EditorCam>>,
     mut toggled: Local<bool>,
 ) {

--- a/crates/bevy_editor_cam/examples/split_screen.rs
+++ b/crates/bevy_editor_cam/examples/split_screen.rs
@@ -1,10 +1,6 @@
 //! Renders two cameras to the same window to accomplish "split screen".
 
-use bevy::{
-    prelude::*,
-    render::{camera::Viewport, view::Hdr},
-    window::WindowResized,
-};
+use bevy::{camera::Viewport, prelude::*, render::view::Hdr, window::WindowResized};
 use bevy_editor_cam::prelude::*;
 
 fn main() {

--- a/crates/bevy_editor_cam/examples/split_screen.rs
+++ b/crates/bevy_editor_cam/examples/split_screen.rs
@@ -74,7 +74,7 @@ struct RightCamera;
 
 fn set_camera_viewports(
     windows: Query<&Window>,
-    mut resize_events: EventReader<WindowResized>,
+    mut resize_events: MessageReader<WindowResized>,
     mut left_camera: Query<&mut Camera, (With<LeftCamera>, Without<RightCamera>)>,
     mut right_camera: Query<&mut Camera, With<RightCamera>>,
 ) {

--- a/crates/bevy_editor_cam/examples/zoom_limits.rs
+++ b/crates/bevy_editor_cam/examples/zoom_limits.rs
@@ -88,7 +88,7 @@ fn setup_ui(mut commands: Commands) {
 
 fn toggle_projection(
     keys: Res<ButtonInput<KeyCode>>,
-    mut dolly: EventWriter<DollyZoomTrigger>,
+    mut dolly: MessageWriter<DollyZoomTrigger>,
     cam: Query<Entity, With<EditorCam>>,
     mut toggled: Local<bool>,
 ) {

--- a/crates/bevy_editor_cam/src/controller/component.rs
+++ b/crates/bevy_editor_cam/src/controller/component.rs
@@ -303,7 +303,7 @@ impl EditorCam {
     /// Called once every frame to compute motions and update the transforms of all [`EditorCam`]s
     pub fn update_camera_positions(
         mut cameras: Query<(&mut EditorCam, &Camera, &mut Transform, &mut Projection)>,
-        mut event: EventWriter<RequestRedraw>,
+        mut event: MessageWriter<RequestRedraw>,
         time: Res<Time>,
     ) {
         for (mut camera_controller, camera, ref mut transform, ref mut projection) in
@@ -321,7 +321,7 @@ impl EditorCam {
         camera: &Camera,
         cam_transform: &mut Transform,
         projection: &mut Projection,
-        redraw: &mut EventWriter<RequestRedraw>,
+        redraw: &mut MessageWriter<RequestRedraw>,
         delta_time: Duration,
     ) {
         let (anchor, orbit, pan, zoom) = match &mut self.current_motion {

--- a/crates/bevy_editor_cam/src/controller/component.rs
+++ b/crates/bevy_editor_cam/src/controller/component.rs
@@ -5,12 +5,12 @@ use std::{
     time::Duration,
 };
 
+use bevy::camera::prelude::*;
 use bevy::ecs::prelude::*;
 use bevy::log::prelude::*;
 use bevy::math::{DMat4, DQuat, DVec2, DVec3, prelude::*};
 use bevy::platform::time::Instant;
 use bevy::reflect::prelude::*;
-use bevy::render::prelude::*;
 use bevy::time::prelude::*;
 use bevy::transform::prelude::*;
 use bevy::window::RequestRedraw;

--- a/crates/bevy_editor_cam/src/controller/projections.rs
+++ b/crates/bevy_editor_cam/src/controller/projections.rs
@@ -1,8 +1,8 @@
 //! Configurable options for the challenge of working with orthographic cameras.
 
+use bevy::camera::prelude::*;
 use bevy::ecs::prelude::*;
 use bevy::reflect::prelude::*;
-use bevy::render::prelude::*;
 use bevy::transform::prelude::*;
 
 use crate::prelude::*;

--- a/crates/bevy_editor_cam/src/controller/zoom.rs
+++ b/crates/bevy_editor_cam/src/controller/zoom.rs
@@ -1,8 +1,8 @@
 //! Provides [`ZoomLimits`] settings.
 
+use bevy::camera::Camera;
 use bevy::math::{DVec2, DVec3};
 use bevy::reflect::Reflect;
-use bevy::render::prelude::*;
 
 /// Bound zooming scale, and define behavior at the limits of zoom.
 #[derive(Debug, Clone, Reflect)]

--- a/crates/bevy_editor_cam/src/extensions/anchor_indicator.rs
+++ b/crates/bevy_editor_cam/src/extensions/anchor_indicator.rs
@@ -36,19 +36,21 @@ impl Plugin for AnchorIndicatorPlugin {
                             margin: UiRect::all(Val::Px(-12.)),
                             ..default()
                         },
-                        UiTargetCamera(trigger.target()),
+                        UiTargetCamera(trigger.event().event_target()),
                         Pickable::IGNORE,
                     ))
                     .id();
 
-                commands.entity(trigger.target()).insert(AnchorRoot(id));
+                commands
+                    .entity(trigger.event().event_target())
+                    .insert(AnchorRoot(id));
             },
         )
         .add_observer(
             |trigger: On<Remove, AnchorRoot>,
              mut commands: Commands,
              anchor_root_query: Query<&AnchorRoot>| {
-                if let Ok(anchor_root) = anchor_root_query.get(trigger.target()) {
+                if let Ok(anchor_root) = anchor_root_query.get(trigger.event().event_target()) {
                     commands.entity(anchor_root.0).despawn();
                 }
             },

--- a/crates/bevy_editor_cam/src/extensions/anchor_indicator.rs
+++ b/crates/bevy_editor_cam/src/extensions/anchor_indicator.rs
@@ -17,7 +17,7 @@ impl Plugin for AnchorIndicatorPlugin {
             PostUpdate,
             draw_anchor
                 .after(TransformSystems::Propagate)
-                .after(bevy::render::camera::CameraUpdateSystems),
+                .after(bevy::camera::CameraUpdateSystems),
         )
         .add_observer(
             |trigger: On<Add, EditorCam>,

--- a/crates/bevy_editor_cam/src/extensions/dolly_zoom.rs
+++ b/crates/bevy_editor_cam/src/extensions/dolly_zoom.rs
@@ -6,12 +6,12 @@
 use std::time::Duration;
 
 use bevy::app::prelude::*;
+use bevy::camera::{ScalingMode, prelude::*};
 use bevy::ecs::prelude::*;
 use bevy::math::prelude::*;
 use bevy::platform::collections::HashMap;
 use bevy::platform::time::Instant;
 use bevy::reflect::prelude::*;
-use bevy::render::{camera::ScalingMode, prelude::*};
 use bevy::transform::prelude::*;
 use bevy::window::RequestRedraw;
 
@@ -36,7 +36,7 @@ impl Plugin for DollyZoomPlugin {
 const ZERO_FOV: f64 = 1e-3;
 
 /// Triggers a dolly zoom on the specified camera.
-#[derive(Debug, Event, BufferedEvent)]
+#[derive(Debug, Event, Message)]
 pub struct DollyZoomTrigger {
     /// The new projection.
     pub target_projection: Projection,

--- a/crates/bevy_editor_cam/src/extensions/dolly_zoom.rs
+++ b/crates/bevy_editor_cam/src/extensions/dolly_zoom.rs
@@ -23,7 +23,7 @@ pub struct DollyZoomPlugin;
 impl Plugin for DollyZoomPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<DollyZoom>()
-            .add_event::<DollyZoomTrigger>()
+            .add_message::<DollyZoomTrigger>()
             .add_systems(
                 PreUpdate,
                 DollyZoom::update.before(EditorCam::update_camera_positions),
@@ -46,10 +46,10 @@ pub struct DollyZoomTrigger {
 
 impl DollyZoomTrigger {
     fn receive(
-        mut events: EventReader<Self>,
+        mut events: MessageReader<Self>,
         mut state: ResMut<DollyZoom>,
         mut cameras: Query<(&Camera, &mut Projection, &mut EditorCam, &mut Transform)>,
-        mut redraw: EventWriter<RequestRedraw>,
+        mut redraw: MessageWriter<RequestRedraw>,
     ) {
         for event in events.read() {
             let Ok((camera, mut proj, mut controller, mut transform)) =
@@ -167,7 +167,7 @@ impl DollyZoom {
     fn update(
         mut state: ResMut<Self>,
         mut cameras: Query<(&Camera, &mut Projection, &mut Transform, &mut EditorCam)>,
-        mut redraw: EventWriter<RequestRedraw>,
+        mut redraw: MessageWriter<RequestRedraw>,
     ) {
         let animation_duration = state.animation_duration;
         let animation_curve = state.animation_curve;

--- a/crates/bevy_editor_cam/src/extensions/independent_skybox.rs
+++ b/crates/bevy_editor_cam/src/extensions/independent_skybox.rs
@@ -7,14 +7,12 @@
 
 use bevy::app::prelude::*;
 use bevy::asset::Handle;
-use bevy::core_pipeline::{Skybox, prelude::*};
+use bevy::camera::{prelude::*, visibility::RenderLayers};
+use bevy::core_pipeline::Skybox;
 use bevy::ecs::prelude::*;
 use bevy::image::Image;
 use bevy::reflect::prelude::*;
-use bevy::render::{
-    prelude::*,
-    view::{Hdr, RenderLayers},
-};
+use bevy::render::view::Hdr;
 use bevy::transform::prelude::*;
 
 /// See the [module](self) docs.

--- a/crates/bevy_editor_cam/src/extensions/look_to.rs
+++ b/crates/bevy_editor_cam/src/extensions/look_to.rs
@@ -20,7 +20,7 @@ pub struct LookToPlugin;
 impl Plugin for LookToPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LookTo>()
-            .add_event::<LookToTrigger>()
+            .add_message::<LookToTrigger>()
             .add_systems(
                 PreUpdate,
                 LookTo::update.before(EditorCam::update_camera_positions),
@@ -93,10 +93,10 @@ impl LookToTrigger {
 
 impl LookToTrigger {
     fn receive(
-        mut events: EventReader<Self>,
+        mut events: MessageReader<Self>,
         mut state: ResMut<LookTo>,
         mut cameras: Query<(&mut EditorCam, &Transform)>,
-        mut redraw: EventWriter<RequestRedraw>,
+        mut redraw: MessageWriter<RequestRedraw>,
     ) {
         for event in events.read() {
             let Ok((mut controller, transform)) = cameras.get_mut(event.camera) else {
@@ -165,7 +165,7 @@ impl LookTo {
     fn update(
         mut state: ResMut<Self>,
         mut cameras: Query<(&mut Transform, &EditorCam)>,
-        mut redraw: EventWriter<RequestRedraw>,
+        mut redraw: MessageWriter<RequestRedraw>,
     ) {
         let animation_duration = state.animation_duration;
         let animation_curve = state.animation_curve;

--- a/crates/bevy_editor_cam/src/extensions/look_to.rs
+++ b/crates/bevy_editor_cam/src/extensions/look_to.rs
@@ -31,7 +31,7 @@ impl Plugin for LookToPlugin {
 
 /// Send this event to rotate the camera about its anchor until it is looking in the given direction
 /// with the given up direction. Animation speed is configured with the [`LookTo`] resource.
-#[derive(Debug, Event, BufferedEvent)]
+#[derive(Debug, Event, Message)]
 pub struct LookToTrigger {
     /// The new direction to face.
     pub target_facing_direction: Dir3,

--- a/crates/bevy_editor_cam/src/input.rs
+++ b/crates/bevy_editor_cam/src/input.rs
@@ -1,5 +1,6 @@
 //! Provides a default input plugin for the camera. See [`DefaultInputPlugin`].
 
+use bevy::camera::prelude::*;
 use bevy::input::{
     mouse::{MouseScrollUnit, MouseWheel},
     prelude::*,
@@ -7,7 +8,6 @@ use bevy::input::{
 use bevy::math::{DVec2, DVec3, prelude::*};
 use bevy::platform::collections::HashMap;
 use bevy::reflect::prelude::*;
-use bevy::render::prelude::*;
 use bevy::transform::prelude::*;
 use bevy::window::PrimaryWindow;
 use bevy::{app::prelude::*, picking::pointer::PointerInput};
@@ -153,7 +153,7 @@ pub fn default_camera_inputs(
 pub struct CameraPointerMap(HashMap<PointerId, Entity>);
 
 /// Events used when implementing input systems for the [`EditorCam`].
-#[derive(Debug, Clone, Reflect, Event, BufferedEvent)]
+#[derive(Debug, Clone, Reflect, Event, Message)]
 pub enum EditorCamInputEvent {
     /// Send this event to start moving the camera. The anchor and inputs will be computed
     /// automatically until the [`EditorCamInputEvent::End`] event is received.

--- a/crates/bevy_editor_cam/src/input.rs
+++ b/crates/bevy_editor_cam/src/input.rs
@@ -47,7 +47,7 @@ impl From<&MotionInputs> for MotionKind {
 pub struct DefaultInputPlugin;
 impl Plugin for DefaultInputPlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<EditorCamInputEvent>()
+        app.add_message::<EditorCamInputEvent>()
             .init_resource::<CameraPointerMap>()
             .add_systems(
                 PreUpdate,
@@ -67,8 +67,8 @@ impl Plugin for DefaultInputPlugin {
 pub fn default_camera_inputs(
     pointers: Query<(&PointerId, &PointerLocation)>,
     pointer_map: Res<CameraPointerMap>,
-    mut controller: EventWriter<EditorCamInputEvent>,
-    mut mouse_wheel: EventReader<MouseWheel>,
+    mut controller: MessageWriter<EditorCamInputEvent>,
+    mut mouse_wheel: MessageReader<MouseWheel>,
     mouse_input: Res<ButtonInput<MouseButton>>,
     cameras: Query<(Entity, &Camera, &EditorCam)>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
@@ -185,7 +185,7 @@ impl EditorCamInputEvent {
 
     /// Receive [`EditorCamInputEvent`]s, and use these to start and end moves on the [`EditorCam`].
     pub fn receive_events(
-        mut events: EventReader<Self>,
+        mut events: MessageReader<Self>,
         mut controllers: Query<(&mut EditorCam, &GlobalTransform)>,
         mut camera_map: ResMut<CameraPointerMap>,
         pointer_map: Res<PointerMap>,
@@ -271,8 +271,8 @@ impl EditorCamInputEvent {
     pub fn send_pointer_inputs(
         camera_map: Res<CameraPointerMap>,
         mut camera_controllers: Query<&mut EditorCam>,
-        mut mouse_wheel: EventReader<MouseWheel>,
-        mut moves: EventReader<PointerInput>,
+        mut mouse_wheel: MessageReader<MouseWheel>,
+        mut moves: MessageReader<PointerInput>,
     ) {
         let moves_list: Vec<_> = moves.read().collect();
         for (pointer, camera) in camera_map.iter() {

--- a/crates/bevy_editor_camera/src/editor_camera_2d/mod.rs
+++ b/crates/bevy_editor_camera/src/editor_camera_2d/mod.rs
@@ -8,10 +8,10 @@
 use std::ops::RangeInclusive;
 
 use bevy::{
+    camera::CameraProjection,
     input::mouse::AccumulatedMouseScroll,
     math::bounding::{Aabb2d, BoundingVolume},
     prelude::*,
-    render::camera::CameraProjection,
     window::PrimaryWindow,
 };
 

--- a/crates/bevy_editor_core/src/selection.rs
+++ b/crates/bevy_editor_core/src/selection.rs
@@ -29,7 +29,7 @@ fn selection_handler(
         return;
     }
 
-    let target = trigger.target();
+    let target = trigger.event().event_target();
     if selectable_query.contains(target) {
         trigger.propagate(false);
         let shift = keyboard_input.any_pressed([KeyCode::ShiftLeft, KeyCode::ShiftRight]);

--- a/crates/bevy_editor_core/src/utils.rs
+++ b/crates/bevy_editor_core/src/utils.rs
@@ -25,11 +25,13 @@ impl Plugin for CoreUtilsPlugin {
 }
 
 fn on_press(trigger: On<Pointer<Press>>, mut state: ResMut<DragCancelClickState>) {
-    state.0.insert(trigger.target(), Instant::now());
+    state
+        .0
+        .insert(trigger.event().event_target(), Instant::now());
 }
 
 fn on_drag_start(trigger: On<Pointer<DragStart>>, mut state: ResMut<DragCancelClickState>) {
-    state.0.remove(&trigger.target());
+    state.0.remove(&trigger.event().event_target());
 }
 
 fn on_release(
@@ -82,7 +84,7 @@ impl BoxedScene {
 
 impl Scene for BoxedScene {
     fn patch(&self, context: &mut PatchContext, scene: &mut ResolvedScene) {
-        self.0.patch(context, scene)
+        self.0.patch(context, scene);
     }
 }
 

--- a/crates/bevy_editor_core/src/utils.rs
+++ b/crates/bevy_editor_core/src/utils.rs
@@ -16,7 +16,7 @@ pub struct CoreUtilsPlugin;
 impl Plugin for CoreUtilsPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<DragCancelClickState>()
-            .add_event::<Pointer<DragCancelClick>>()
+            .add_message::<Pointer<DragCancelClick>>()
             .register_type::<Pointer<DragCancelClick>>()
             .add_observer(on_press)
             .add_observer(on_drag_start)

--- a/crates/bevy_editor_core/src/utils.rs
+++ b/crates/bevy_editor_core/src/utils.rs
@@ -6,7 +6,7 @@ use bevy::{
     picking::backend::HitData,
     platform::{collections::HashMap, time::Instant},
     prelude::*,
-    scene2::Scene,
+    scene2::{PatchContext, ResolvedScene, Scene},
 };
 
 /// Editor core utils plugin.
@@ -38,7 +38,7 @@ fn on_release(
     mut commands: Commands,
 ) {
     let now = Instant::now();
-    if let Some(instant) = state.remove(&trigger.target()) {
+    if let Some(instant) = state.remove(&trigger.event().event_target()) {
         let event = Pointer::new(
             trigger.pointer_id,
             trigger.pointer_location.clone(),
@@ -47,9 +47,10 @@ fn on_release(
                 hit: trigger.hit.clone(),
                 duration: now - instant,
             },
+            trigger.event().event_target(),
         );
-        commands.trigger_targets(event.clone(), trigger.target());
-        commands.write_event(event);
+        commands.trigger(event.clone());
+        commands.write_message(event);
     }
 }
 
@@ -80,13 +81,8 @@ impl BoxedScene {
 }
 
 impl Scene for BoxedScene {
-    fn patch(
-        &self,
-        assets: &AssetServer,
-        patches: &Assets<bevy::scene2::ScenePatch>,
-        scene: &mut bevy::scene2::ResolvedScene,
-    ) {
-        self.0.patch(assets, patches, scene);
+    fn patch(&self, context: &mut PatchContext, scene: &mut ResolvedScene) {
+        self.0.patch(context, scene)
     }
 }
 

--- a/crates/bevy_editor_launcher/src/ui.rs
+++ b/crates/bevy_editor_launcher/src/ui.rs
@@ -198,7 +198,7 @@ pub(crate) fn spawn_project_node<'a>(
          theme: Res<Theme>| {
             let project = {
                 let text = {
-                    let project_entity = trigger.target();
+                    let project_entity = trigger.event().event_target();
                     let project_children = query_children.get(project_entity).unwrap();
                     let text_container = project_children.get(1).expect(
                         "Expected project node to have 2 children, (the second being a container for the name)"
@@ -233,7 +233,7 @@ pub(crate) fn spawn_project_node<'a>(
                 project_list.0.retain(|p| p.path != project.path);
                 set_project_list(project_list.0.clone());
                 // Remove project node from UI
-                let project_entity = trigger.target();
+                let project_entity = trigger.event().event_target();
                 commands.entity(project_entity).despawn();
                 return;
             }
@@ -258,7 +258,7 @@ pub(crate) fn spawn_project_node<'a>(
                             project_list.0.retain(|p| p.path != project.path);
                             set_project_list(project_list.0.clone());
                             // Remove project node from UI
-                            let project_entity = trigger.target();
+                            let project_entity = trigger.event().event_target();
                             commands.entity(project_entity).despawn();
                         }
                         _ => {

--- a/crates/bevy_editor_launcher/src/ui.rs
+++ b/crates/bevy_editor_launcher/src/ui.rs
@@ -193,7 +193,7 @@ pub(crate) fn spawn_project_node<'a>(
          mut commands: Commands,
          query_children: Query<&Children>,
          query_text: Query<&Text>,
-         mut exit: EventWriter<AppExit>,
+         mut exit: MessageWriter<AppExit>,
          mut project_list: ResMut<ProjectInfoList>,
          theme: Res<Theme>| {
             let project = {

--- a/crates/bevy_infinite_grid/examples/simple.rs
+++ b/crates/bevy_infinite_grid/examples/simple.rs
@@ -84,7 +84,7 @@ mod camera_controller {
 
     fn camera_controller(
         time: Res<Time>,
-        mut mouse_events: EventReader<MouseMotion>,
+        mut mouse_events: MessageReader<MouseMotion>,
         mouse_button_input: Res<ButtonInput<MouseButton>>,
         key_input: Res<ButtonInput<KeyCode>>,
         mut query: Query<(&mut Transform, &mut CameraController), With<Camera>>,

--- a/crates/bevy_infinite_grid/src/lib.rs
+++ b/crates/bevy_infinite_grid/src/lib.rs
@@ -2,7 +2,7 @@
 
 mod render;
 
-use bevy::render::view::{
+use bevy::camera::visibility::{
     NoFrustumCulling, VisibilityClass, VisibleEntities, add_visibility_class,
 };
 use bevy::{prelude::*, render::sync_world::SyncToRenderWorld};

--- a/crates/bevy_infinite_grid/src/render/mod.rs
+++ b/crates/bevy_infinite_grid/src/render/mod.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 
 use bevy::{
     asset::{load_internal_asset, uuid_handle},
+    camera::visibility::VisibleEntities,
     core_pipeline::{core_2d::Transparent2d, core_3d::Transparent3d},
     ecs::{
         query::ROQueryItem,
@@ -12,11 +13,11 @@ use bevy::{
     },
     image::BevyDefault,
     math::FloatOrd,
+    mesh::PrimitiveTopology,
     pbr::MeshPipelineKey,
     prelude::*,
     render::{
         Extract, ExtractSchedule, Render, RenderApp, RenderSystems,
-        mesh::PrimitiveTopology,
         render_phase::{
             AddRenderCommand, DrawFunctions, PhaseItem, PhaseItemExtraIndex, RenderCommand,
             RenderCommandResult, SetItemPipeline, ViewSortedRenderPhases,
@@ -31,7 +32,7 @@ use bevy::{
         },
         renderer::{RenderDevice, RenderQueue},
         sync_world::RenderEntity,
-        view::{ExtractedView, RenderVisibleEntities, ViewTarget, VisibleEntities},
+        view::{ExtractedView, RenderVisibleEntities, ViewTarget},
     },
 };
 

--- a/crates/bevy_pane_layout/src/components.rs
+++ b/crates/bevy_pane_layout/src/components.rs
@@ -2,15 +2,12 @@
 
 use bevy::{
     ecs::template::template,
-    feathers::{
-        containers::{pane, pane_body, pane_header},
-        theme::ThemeBackgroundColor,
-        tokens,
-    },
+    feathers::theme::ThemeBackgroundColor,
     prelude::*,
     scene2::{Scene, bsn},
 };
 
+use crate::containers::{pane, pane_body, pane_header, tokens};
 use crate::{PaneContentNode, PaneHeaderNode, ui::header_context_menu};
 
 /// A standard editor pane.

--- a/crates/bevy_pane_layout/src/containers/flex_spacer.rs
+++ b/crates/bevy_pane_layout/src/containers/flex_spacer.rs
@@ -1,0 +1,11 @@
+use bevy::scene2::{Scene, bsn};
+use bevy::ui::Node;
+
+/// An invisible UI node that takes up space, and which has a positive `flex_grow` setting.
+pub fn flex_spacer() -> impl Scene {
+    bsn! {
+        Node {
+            flex_grow: 1.0,
+        }
+    }
+}

--- a/crates/bevy_pane_layout/src/containers/mod.rs
+++ b/crates/bevy_pane_layout/src/containers/mod.rs
@@ -1,0 +1,52 @@
+//! Meta-module containing all feathers containers (passive widgets that hold other widgets).
+mod flex_spacer;
+mod pane;
+mod subpane;
+
+pub use flex_spacer::flex_spacer;
+pub use pane::{pane, pane_body, pane_header, pane_header_divider};
+pub use subpane::{subpane, subpane_body, subpane_header};
+
+/// Size constants
+pub mod size {
+    use bevy::ui::Val;
+
+    /// Height for pane headers
+    pub const HEADER_HEIGHT: Val = Val::Px(30.0);
+
+    /// Common size for toolbar buttons.
+    pub const TOOL_HEIGHT: Val = Val::Px(18.0);
+}
+
+pub mod tokens {
+    use bevy::feathers::theme::ThemeToken;
+
+    // Pane
+
+    /// Pane header background
+    pub const PANE_HEADER_BG: ThemeToken = ThemeToken::new_static("feathers.pane.header.bg");
+    /// Pane header border
+    pub const PANE_HEADER_BORDER: ThemeToken =
+        ThemeToken::new_static("feathers.pane.header.border");
+    /// Pane header text color
+    pub const PANE_HEADER_TEXT: ThemeToken = ThemeToken::new_static("feathers.pane.header.text");
+    /// Pane header divider color
+    pub const PANE_HEADER_DIVIDER: ThemeToken =
+        ThemeToken::new_static("feathers.pane.header.divider");
+
+    // Subpane
+
+    /// Subpane background
+    pub const SUBPANE_HEADER_BG: ThemeToken = ThemeToken::new_static("feathers.subpane.header.bg");
+    /// Subpane header border
+    pub const SUBPANE_HEADER_BORDER: ThemeToken =
+        ThemeToken::new_static("feathers.subpane.header.border");
+    /// Subpane header text color
+    pub const SUBPANE_HEADER_TEXT: ThemeToken =
+        ThemeToken::new_static("feathers.subpane.header.text");
+    /// Subpane body background
+    pub const SUBPANE_BODY_BG: ThemeToken = ThemeToken::new_static("feathers.subpane.body.bg");
+    /// Subpane body border
+    pub const SUBPANE_BODY_BORDER: ThemeToken =
+        ThemeToken::new_static("feathers.subpane.body.border");
+}

--- a/crates/bevy_pane_layout/src/containers/mod.rs
+++ b/crates/bevy_pane_layout/src/containers/mod.rs
@@ -5,9 +5,26 @@ mod flex_spacer;
 mod pane;
 mod subpane;
 
+use bevy::ecs::system::{Commands, ResMut};
+use bevy::feathers::palette;
+use bevy::feathers::theme::UiTheme;
+
 pub use flex_spacer::flex_spacer;
 pub use pane::{pane, pane_body, pane_header, pane_header_divider};
 pub use subpane::{subpane, subpane_body, subpane_header};
+
+pub fn setup(mut theme: ResMut<UiTheme>) {
+    theme.set_color("feathers.pane.header.bg", palette::GRAY_0);
+    theme.set_color("feathers.pane.header.border", palette::WARM_GRAY_1);
+    theme.set_color("feathers.pane.header.text", palette::LIGHT_GRAY_1);
+    theme.set_color("feathers.pane.header.divider", palette::WARM_GRAY_1);
+
+    theme.set_color("feathers.subpane.header.bg", palette::GRAY_2);
+    theme.set_color("feathers.subpane.header.border", palette::GRAY_3);
+    theme.set_color("feathers.subpane.header.text", palette::LIGHT_GRAY_1);
+    theme.set_color("feathers.subpane.body.bg", palette::GRAY_1);
+    theme.set_color("feathers.subpane.body.border", palette::GRAY_2);
+}
 
 /// Size constants
 pub mod size {

--- a/crates/bevy_pane_layout/src/containers/mod.rs
+++ b/crates/bevy_pane_layout/src/containers/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused)] // FIXME: This module is part of https://github.com/cart/bevy/pull/34 
+
 //! Meta-module containing all feathers containers (passive widgets that hold other widgets).
 mod flex_spacer;
 mod pane;

--- a/crates/bevy_pane_layout/src/containers/mod.rs
+++ b/crates/bevy_pane_layout/src/containers/mod.rs
@@ -1,4 +1,4 @@
-#![allow(unused)] // FIXME: This module is part of https://github.com/cart/bevy/pull/34 
+#![allow(unused)] // FIXME: This module is part of https://github.com/cart/bevy/pull/34
 
 //! Meta-module containing all feathers containers (passive widgets that hold other widgets).
 mod flex_spacer;

--- a/crates/bevy_pane_layout/src/containers/pane.rs
+++ b/crates/bevy_pane_layout/src/containers/pane.rs
@@ -1,0 +1,86 @@
+use bevy::feathers::{
+    constants::fonts,
+    font_styles::InheritableFont,
+    rounded_corners::RoundedCorners,
+    theme::{ThemeBackgroundColor, ThemeBorderColor, ThemeFontColor},
+};
+use bevy::scene2::{Scene, bsn, template_value};
+use bevy::ui::{
+    AlignItems, AlignSelf, Display, FlexDirection, JustifyContent, Node, PositionType, UiRect, Val,
+};
+
+use super::{size, tokens};
+
+/// A standard pane
+pub fn pane() -> impl Scene {
+    bsn! {
+        Node {
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            align_items: AlignItems::Stretch,
+        }
+    }
+}
+
+/// Pane header
+pub fn pane_header() -> impl Scene {
+    bsn! {
+        Node {
+            display: Display::Flex,
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::SpaceBetween,
+            padding: UiRect::axes(Val::Px(6.0), Val::Px(6.0)),
+            border: UiRect {
+                left: Val::Px(1.0),
+                top: Val::Px(1.0),
+                right: Val::Px(1.0),
+                bottom: Val::Px(0.0),
+            },
+            min_height: size::HEADER_HEIGHT,
+            column_gap: Val::Px(6.0),
+        }
+        ThemeBackgroundColor(tokens::PANE_HEADER_BG)
+        ThemeBorderColor(tokens::PANE_HEADER_BORDER)
+        ThemeFontColor(tokens::PANE_HEADER_TEXT)
+        template_value(RoundedCorners::Top.to_border_radius(4.0))
+        InheritableFont {
+            font: fonts::REGULAR,
+            font_size: 14.0,
+        }
+    }
+}
+
+/// Divider between groups of widgets in pane headers
+pub fn pane_header_divider() -> impl Scene {
+    bsn! {
+        Node {
+            width: Val::Px(1.0),
+            align_self: AlignSelf::Stretch,
+        }
+        [(
+            // Because we want to extend the divider into the header padding area, we'll use
+            // an absolutely-positioned child.
+            Node {
+                position_type: PositionType::Absolute,
+                left: Val::Px(0.0),
+                right: Val::Px(0.0),
+                top: Val::Px(-6.0),
+                bottom: Val::Px(-6.0),
+            }
+            ThemeBackgroundColor(tokens::PANE_HEADER_DIVIDER)
+        )]
+    }
+}
+
+/// Pane body
+pub fn pane_body() -> impl Scene {
+    bsn! {
+        Node {
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            padding: UiRect::axes(Val::Px(6.0), Val::Px(6.0)),
+        }
+        template_value(RoundedCorners::Bottom.to_border_radius(4.0))
+    }
+}

--- a/crates/bevy_pane_layout/src/containers/subpane.rs
+++ b/crates/bevy_pane_layout/src/containers/subpane.rs
@@ -1,0 +1,74 @@
+use bevy::feathers::{
+    constants::fonts,
+    font_styles::InheritableFont,
+    rounded_corners::RoundedCorners,
+    theme::{ThemeBackgroundColor, ThemeBorderColor, ThemeFontColor},
+};
+use bevy::scene2::{Scene, bsn, template_value};
+use bevy::ui::{AlignItems, Display, FlexDirection, JustifyContent, Node, UiRect, Val};
+
+use super::{size, tokens};
+
+/// Sub-pane
+pub fn subpane() -> impl Scene {
+    bsn! {
+        Node {
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            align_items: AlignItems::Stretch,
+        }
+    }
+}
+
+/// Sub-pane header
+pub fn subpane_header() -> impl Scene {
+    bsn! {
+        Node {
+            display: Display::Flex,
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::SpaceBetween,
+            border: UiRect {
+                left: Val::Px(1.0),
+                top: Val::Px(1.0),
+                right: Val::Px(1.0),
+                bottom: Val::Px(0.0),
+            },
+            padding: UiRect::axes(Val::Px(10.0), Val::Px(0.0)),
+            min_height: size::HEADER_HEIGHT,
+            column_gap: Val::Px(4.0),
+        }
+        ThemeBackgroundColor(tokens::SUBPANE_HEADER_BG)
+        ThemeBorderColor(tokens::SUBPANE_HEADER_BORDER)
+        ThemeFontColor(tokens::SUBPANE_HEADER_TEXT)
+        template_value(RoundedCorners::Top.to_border_radius(4.0))
+        InheritableFont {
+            font: fonts::REGULAR,
+            font_size: 14.0,
+        }
+    }
+}
+
+/// Sub-pane body
+pub fn subpane_body() -> impl Scene {
+    bsn! {
+        Node {
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            border: UiRect {
+                left: Val::Px(1.0),
+                top: Val::Px(0.0),
+                right: Val::Px(1.0),
+                bottom: Val::Px(1.0),
+            },
+            padding: UiRect::axes(Val::Px(6.0), Val::Px(6.0)),
+        }
+        ThemeBackgroundColor(tokens::SUBPANE_BODY_BG)
+        ThemeBorderColor(tokens::SUBPANE_BODY_BORDER)
+        template_value(RoundedCorners::Bottom.to_border_radius(4.0))
+        InheritableFont {
+            font: fonts::REGULAR,
+            font_size: 14.0,
+        }
+    }
+}

--- a/crates/bevy_pane_layout/src/lib.rs
+++ b/crates/bevy_pane_layout/src/lib.rs
@@ -20,7 +20,7 @@ mod ui;
 /// - Panes cannot have min/max sizes, they must be able to be resized to any size.
 ///   - If a pane can not be sensibly resized, it can overflow under the other panes.
 /// - Panes must not interfere with each other, only temporary/absolute positioned elements are allowed to overlap panes.
-use bevy::prelude::*;
+use bevy::{feathers::theme::UiTheme, prelude::*};
 use bevy_editor_styles::Theme;
 
 use crate::{
@@ -98,8 +98,11 @@ pub struct PaneLayoutSet;
 fn setup(
     mut commands: Commands,
     theme: Res<Theme>,
+    ui_theme: ResMut<UiTheme>,
     panes_root: Single<Entity, With<RootPaneLayoutNode>>,
 ) {
+    containers::setup(ui_theme);
+
     commands.entity(*panes_root).insert((
         Node {
             padding: UiRect::all(Val::Px(1.)),

--- a/crates/bevy_pane_layout/src/lib.rs
+++ b/crates/bevy_pane_layout/src/lib.rs
@@ -1,6 +1,7 @@
 //! Resizable, divider-able panes for Bevy.
 
 pub mod components;
+mod containers;
 mod handlers;
 mod pane_drop_area;
 pub mod registry;

--- a/crates/bevy_pane_layout/src/ui.rs
+++ b/crates/bevy_pane_layout/src/ui.rs
@@ -214,7 +214,7 @@ pub(crate) fn spawn_resize_handle<'a>(
 
             drag_state.is_dragging = true;
 
-            let target = trigger.target();
+            let target = trigger.event().event_target();
             let parent = parent_query.get(target).unwrap().parent();
 
             let parent_node_size = computed_node_query.get(parent).unwrap().size();
@@ -247,7 +247,7 @@ pub(crate) fn spawn_resize_handle<'a>(
                 return;
             }
 
-            let target = trigger.target();
+            let target = trigger.event().event_target();
             let parent = parent_query.get(target).unwrap().parent();
             let siblings = children_query.get(parent).unwrap();
             // Find the index of this handle among its siblings

--- a/crates/bevy_proto_bsn/examples/bsn_asset.rs
+++ b/crates/bevy_proto_bsn/examples/bsn_asset.rs
@@ -29,7 +29,7 @@ struct SceneRoot(Handle<ReflectedBsn>);
 
 fn spawn_and_reload_scene(
     scene_root: Single<Entity, With<SceneRoot>>,
-    mut events: EventReader<AssetEvent<ReflectedBsn>>,
+    mut events: MessageReader<AssetEvent<ReflectedBsn>>,
     bsn_assets: Res<Assets<ReflectedBsn>>,
     mut commands: Commands,
 ) {

--- a/crates/bevy_proto_bsn/src/bsn_helpers.rs
+++ b/crates/bevy_proto_bsn/src/bsn_helpers.rs
@@ -13,11 +13,6 @@ use bevy::{
 
 use crate::{Construct, ConstructEntity, ConstructProp, EntityPath};
 
-/// Shorthand for [`Val::Px`].
-pub fn px(value: impl Into<f32>) -> Val {
-    Val::Px(value.into())
-}
-
 /// Shorthand for [`UiRect::all`] + [`Val::Px`].
 pub fn px_all(value: impl Into<f32>) -> UiRect {
     UiRect::all(Val::Px(value.into()))

--- a/crates/bevy_proto_bsn/src/construct.rs
+++ b/crates/bevy_proto_bsn/src/construct.rs
@@ -7,7 +7,7 @@ use bevy::{
         world::error::EntityMutableFetchError,
     },
     prelude::*,
-    ptr::OwningPtr,
+    ptr::{MovingPtr, OwningPtr, deconstruct_moving_ptr},
 };
 use thiserror::Error;
 use variadics_please::all_tuples;
@@ -220,7 +220,24 @@ unsafe impl<B: BundleFromComponents> BundleFromComponents for ConstructTuple<B> 
 impl<B: Bundle> DynamicBundle for ConstructTuple<B> {
     type Effect = ();
 
-    fn get_components(self, func: &mut impl FnMut(StorageType, OwningPtr<'_>)) {
-        self.0.get_components(func);
+    #[allow(unused_variables, unsafe_code)]
+    #[inline]
+    unsafe fn get_components(
+        ptr: MovingPtr<'_, Self>,
+        func: &mut impl FnMut(StorageType, OwningPtr<'_>),
+    ) {
+        deconstruct_moving_ptr!({
+            let ConstructTuple { 0: field0 } = ptr;
+        });
+
+        unsafe { <B as DynamicBundle>::get_components(field0, func) };
+    }
+
+    #[allow(unused_variables, unsafe_code)]
+    #[inline]
+    unsafe fn apply_effect(
+        _ptr: MovingPtr<'_, std::mem::MaybeUninit<Self>>,
+        _entity: &mut EntityWorldMut,
+    ) {
     }
 }

--- a/crates/bevy_proto_bsn/src/construct.rs
+++ b/crates/bevy_proto_bsn/src/construct.rs
@@ -230,6 +230,7 @@ impl<B: Bundle> DynamicBundle for ConstructTuple<B> {
             let ConstructTuple { 0: field0 } = ptr;
         });
 
+        // SAFETY: B::get_components has the same constraints as Self::get_components
         unsafe { <B as DynamicBundle>::get_components(field0, func) };
     }
 

--- a/crates/bevy_proto_bsn/src/construct_reflect.rs
+++ b/crates/bevy_proto_bsn/src/construct_reflect.rs
@@ -85,21 +85,35 @@ pub(crate) fn register_reflect_construct(app: &mut App) {
     app.register_type_data::<bevy::audio::PlaybackSettings, ReflectConstruct>();
     app.register_type_data::<bevy::audio::SpatialListener, ReflectConstruct>();
 
-    app.register_type_data::<bevy::anti_aliasing::contrast_adaptive_sharpening::ContrastAdaptiveSharpening, ReflectConstruct>();
-    app.register_type_data::<bevy::anti_aliasing::contrast_adaptive_sharpening::DenoiseCas, ReflectConstruct>();
-    app.register_type_data::<bevy::anti_aliasing::fxaa::Fxaa, ReflectConstruct>();
-    app.register_type_data::<bevy::anti_aliasing::smaa::Smaa, ReflectConstruct>();
-    app.register_type_data::<bevy::anti_aliasing::taa::TemporalAntiAliasing, ReflectConstruct>();
+    app.register_type_data::<bevy::anti_alias::contrast_adaptive_sharpening::ContrastAdaptiveSharpening, ReflectConstruct>();
+    app.register_type_data::<bevy::anti_alias::contrast_adaptive_sharpening::DenoiseCas, ReflectConstruct>();
+    app.register_type_data::<bevy::anti_alias::fxaa::Fxaa, ReflectConstruct>();
+    app.register_type_data::<bevy::anti_alias::smaa::Smaa, ReflectConstruct>();
+    app.register_type_data::<bevy::anti_alias::taa::TemporalAntiAliasing, ReflectConstruct>();
 
-    app.register_type_data::<bevy::core_pipeline::auto_exposure::AutoExposure, ReflectConstruct>();
-    app.register_type_data::<bevy::core_pipeline::bloom::Bloom, ReflectConstruct>();
-    app.register_type_data::<bevy::core_pipeline::core_2d::Camera2d, ReflectConstruct>();
-    app.register_type_data::<bevy::core_pipeline::core_3d::Camera3d, ReflectConstruct>();
-    app.register_type_data::<bevy::core_pipeline::dof::DepthOfField, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::Camera, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::Camera2d, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::Camera3d, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::CameraMainTextureUsages, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::Exposure, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::ManualTextureViewHandle, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::CustomProjection, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::Visibility, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::InheritedVisibility, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::VisibilityRange, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::RenderLayers, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::ViewVisibility, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::VisibilityClass, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::VisibleEntities, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::CascadesVisibleEntities, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::CubemapVisibleEntities, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::visibility::VisibleMeshEntities, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::primitives::Aabb, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::primitives::CascadesFrusta, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::primitives::CubemapFrusta, ReflectConstruct>();
+    app.register_type_data::<bevy::camera::primitives::Frustum, ReflectConstruct>();
 
-    app.register_type_data::<bevy::core_pipeline::motion_blur::MotionBlur, ReflectConstruct>();
     app.register_type_data::<bevy::core_pipeline::oit::OrderIndependentTransparencySettings, ReflectConstruct>();
-    app.register_type_data::<bevy::core_pipeline::post_process::ChromaticAberration, ReflectConstruct>();
     app.register_type_data::<bevy::core_pipeline::prepass::DepthPrepass, ReflectConstruct>();
     app.register_type_data::<bevy::core_pipeline::prepass::MotionVectorPrepass, ReflectConstruct>();
     app.register_type_data::<bevy::core_pipeline::prepass::NormalPrepass, ReflectConstruct>();
@@ -121,34 +135,38 @@ pub(crate) fn register_reflect_construct(app: &mut App) {
 
     app.register_type_data::<bevy::input::gamepad::GamepadSettings, ReflectConstruct>();
 
+    app.register_type_data::<bevy::light::LightProbe, ReflectConstruct>();
+    app.register_type_data::<bevy::light::AmbientLight, ReflectConstruct>();
+    app.register_type_data::<bevy::light::Cascades, ReflectConstruct>();
+    app.register_type_data::<bevy::light::CascadeShadowConfig, ReflectConstruct>();
+    app.register_type_data::<bevy::light::DirectionalLight, ReflectConstruct>();
+    app.register_type_data::<bevy::light::PointLight, ReflectConstruct>();
+    app.register_type_data::<bevy::light::SpotLight, ReflectConstruct>();
+    app.register_type_data::<bevy::light::IrradianceVolume, ReflectConstruct>();
+    app.register_type_data::<bevy::light::FogVolume, ReflectConstruct>();
+    app.register_type_data::<bevy::light::VolumetricFog, ReflectConstruct>();
+    app.register_type_data::<bevy::light::VolumetricLight, ReflectConstruct>();
+
     app.register_type_data::<bevy::pbr::Atmosphere, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::AtmosphereSettings, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::CascadesVisibleEntities, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::CubemapVisibleEntities, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::RenderCascadesVisibleEntities, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::RenderCubemapVisibleEntities, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::RenderVisibleMeshEntities, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::VisibleMeshEntities, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::DistanceFog, ReflectConstruct>();
     app.register_type_data::<bevy::prelude::EnvironmentMapLight, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::irradiance_volume::IrradianceVolume, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::LightProbe, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::AmbientLight, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::Cascades, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::CascadeShadowConfig, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::DirectionalLight, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::PointLight, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::SpotLight, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::Lightmap, ReflectConstruct>();
     //app.register_type_data::<bevy::pbr::MeshMaterial3d, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::ScreenSpaceAmbientOcclusion, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::ScreenSpaceReflections, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::FogVolume, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::VolumetricFog, ReflectConstruct>();
-    app.register_type_data::<bevy::pbr::VolumetricLight, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::wireframe::NoWireframe, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::wireframe::Wireframe, ReflectConstruct>();
     app.register_type_data::<bevy::pbr::wireframe::WireframeColor, ReflectConstruct>();
+
+    app.register_type_data::<bevy::post_process::auto_exposure::AutoExposure, ReflectConstruct>();
+    app.register_type_data::<bevy::post_process::bloom::Bloom, ReflectConstruct>();
+    app.register_type_data::<bevy::post_process::dof::DepthOfField, ReflectConstruct>();
+    app.register_type_data::<bevy::post_process::effect_stack::ChromaticAberration, ReflectConstruct>();
+    app.register_type_data::<bevy::post_process::motion_blur::MotionBlur, ReflectConstruct>();
 
     app.register_type_data::<bevy::picking::mesh_picking::ray_cast::RayCastBackfaces, ReflectConstruct>();
     app.register_type_data::<bevy::picking::mesh_picking::MeshPickingCamera, ReflectConstruct>();
@@ -157,44 +175,31 @@ pub(crate) fn register_reflect_construct(app: &mut App) {
     app.register_type_data::<bevy::picking::pointer::PointerLocation, ReflectConstruct>();
     app.register_type_data::<bevy::picking::pointer::PointerPress, ReflectConstruct>();
 
-    app.register_type_data::<bevy::render::camera::Camera, ReflectConstruct>();
-    app.register_type_data::<bevy::render::camera::CameraMainTextureUsages, ReflectConstruct>();
-    app.register_type_data::<bevy::render::camera::Exposure, ReflectConstruct>();
     app.register_type_data::<bevy::render::camera::TemporalJitter, ReflectConstruct>();
-    app.register_type_data::<bevy::render::camera::ManualTextureViewHandle, ReflectConstruct>();
-    app.register_type_data::<bevy::render::camera::CustomProjection, ReflectConstruct>();
     app.register_type_data::<bevy::render::experimental::occlusion_culling::OcclusionCulling, ReflectConstruct>();
-    app.register_type_data::<bevy::render::mesh::Mesh2d, ReflectConstruct>();
-    app.register_type_data::<bevy::render::mesh::Mesh3d, ReflectConstruct>();
-    app.register_type_data::<bevy::render::mesh::MeshTag, ReflectConstruct>();
-    app.register_type_data::<bevy::render::mesh::morph::MeshMorphWeights, ReflectConstruct>();
-    app.register_type_data::<bevy::render::mesh::morph::MorphWeights, ReflectConstruct>();
-    app.register_type_data::<bevy::render::mesh::skinning::SkinnedMesh, ReflectConstruct>();
-    app.register_type_data::<bevy::render::primitives::Aabb, ReflectConstruct>();
-    app.register_type_data::<bevy::render::primitives::CascadesFrusta, ReflectConstruct>();
-    app.register_type_data::<bevy::render::primitives::CubemapFrusta, ReflectConstruct>();
-    app.register_type_data::<bevy::render::primitives::Frustum, ReflectConstruct>();
     app.register_type_data::<bevy::render::sync_world::SyncToRenderWorld, ReflectConstruct>();
     app.register_type_data::<bevy::render::sync_world::TemporaryRenderEntity, ReflectConstruct>();
     app.register_type_data::<bevy::render::view::ColorGrading, ReflectConstruct>();
-    app.register_type_data::<bevy::render::view::visibility::Visibility, ReflectConstruct>();
-    app.register_type_data::<bevy::render::view::visibility::InheritedVisibility, ReflectConstruct>();
-    app.register_type_data::<bevy::render::view::visibility::VisibilityRange, ReflectConstruct>();
-    app.register_type_data::<bevy::render::view::visibility::RenderLayers, ReflectConstruct>();
     app.register_type_data::<bevy::render::view::visibility::RenderVisibleEntities, ReflectConstruct>();
-    app.register_type_data::<bevy::render::view::visibility::ViewVisibility, ReflectConstruct>();
-    app.register_type_data::<bevy::render::view::visibility::VisibilityClass, ReflectConstruct>();
-    app.register_type_data::<bevy::render::view::visibility::VisibleEntities, ReflectConstruct>();
 
     app.register_type_data::<bevy::scene::DynamicSceneRoot, ReflectConstruct>();
     app.register_type_data::<bevy::scene::SceneRoot, ReflectConstruct>();
 
     //app.register_type_data::<bevy::sprite::MeshMaterial2d, ReflectConstruct>();
-    app.register_type_data::<bevy::sprite::NoWireframe2d, ReflectConstruct>();
-    app.register_type_data::<bevy::sprite::Wireframe2d, ReflectConstruct>();
-    app.register_type_data::<bevy::sprite::Wireframe2dColor, ReflectConstruct>();
     app.register_type_data::<bevy::sprite::SpritePickingCamera, ReflectConstruct>();
     app.register_type_data::<bevy::sprite::Sprite, ReflectConstruct>();
+    app.register_type_data::<bevy::sprite::Text2d, ReflectConstruct>();
+
+    app.register_type_data::<bevy::sprite_render::NoWireframe2d, ReflectConstruct>();
+    app.register_type_data::<bevy::sprite_render::Wireframe2d, ReflectConstruct>();
+    app.register_type_data::<bevy::sprite_render::Wireframe2dColor, ReflectConstruct>();
+
+    app.register_type_data::<bevy::mesh::Mesh2d, ReflectConstruct>();
+    app.register_type_data::<bevy::mesh::Mesh3d, ReflectConstruct>();
+    app.register_type_data::<bevy::mesh::MeshTag, ReflectConstruct>();
+    app.register_type_data::<bevy::mesh::morph::MeshMorphWeights, ReflectConstruct>();
+    app.register_type_data::<bevy::mesh::morph::MorphWeights, ReflectConstruct>();
+    app.register_type_data::<bevy::mesh::skinning::SkinnedMesh, ReflectConstruct>();
 
     // app.register_type_data::<bevy::prelude::StateScoped, ReflectConstruct>();
 
@@ -205,7 +210,6 @@ pub(crate) fn register_reflect_construct(app: &mut App) {
     app.register_type_data::<bevy::text::TextFont, ReflectConstruct>();
     app.register_type_data::<bevy::text::TextLayout, ReflectConstruct>();
     app.register_type_data::<bevy::text::TextSpan, ReflectConstruct>();
-    app.register_type_data::<bevy::text::Text2d, ReflectConstruct>();
 
     app.register_type_data::<bevy::transform::components::GlobalTransform, ReflectConstruct>();
     app.register_type_data::<bevy::transform::components::Transform, ReflectConstruct>();
@@ -220,7 +224,7 @@ pub(crate) fn register_reflect_construct(app: &mut App) {
     app.register_type_data::<bevy::ui_render::BoxShadowSamples, ReflectConstruct>();
     app.register_type_data::<bevy::ui::CalculatedClip, ReflectConstruct>();
     app.register_type_data::<bevy::ui::ComputedNode, ReflectConstruct>();
-    app.register_type_data::<bevy::ui::ComputedNodeTarget, ReflectConstruct>();
+    app.register_type_data::<bevy::ui::ComputedUiTargetCamera, ReflectConstruct>();
     app.register_type_data::<bevy::ui::GlobalZIndex, ReflectConstruct>();
     app.register_type_data::<bevy::ui::LayoutConfig, ReflectConstruct>();
     app.register_type_data::<bevy::ui::Node, ReflectConstruct>();

--- a/crates/bevy_transform_gizmos/src/lib.rs
+++ b/crates/bevy_transform_gizmos/src/lib.rs
@@ -72,20 +72,15 @@ pub struct ScaleGizmo;
 pub struct InternalGizmoCamera;
 
 /// Available gizmo modes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum GizmoMode {
     /// Translation mode (W key).
+    #[default]
     Translate,
     /// Rotation mode (E key).
     Rotate,
     /// Scale mode (R key).
     Scale,
-}
-
-impl Default for GizmoMode {
-    fn default() -> Self {
-        Self::Translate
-    }
 }
 
 /// Settings for the [`TransformGizmoPlugin`].
@@ -270,7 +265,7 @@ fn on_transform_gizmo_pointer_press(
     if trigger.button != PointerButton::Primary {
         return;
     }
-    let Ok((interaction, child_of)) = target_query.get(trigger.target()) else {
+    let Ok((interaction, child_of)) = target_query.get(trigger.event().event_target()) else {
         return;
     };
     let Ok((mut gizmo, transform)) = query.get_mut(child_of.parent()) else {

--- a/crates/bevy_transform_gizmos/src/lib.rs
+++ b/crates/bevy_transform_gizmos/src/lib.rs
@@ -131,7 +131,7 @@ impl Plugin for TransformGizmoPlugin {
         }
         app.init_resource::<TransformGizmoSettings>()
             .add_plugins(Ui3dNormalizationPlugin)
-            .add_event::<TransformGizmoEvent>()
+            .add_message::<TransformGizmoEvent>()
             .add_observer(on_transform_gizmo_pointer_press)
             .add_observer(on_transform_gizmo_pointer_release);
 
@@ -295,7 +295,7 @@ fn on_transform_gizmo_pointer_press(
 fn on_transform_gizmo_pointer_release(
     trigger: On<Pointer<Release>>,
     mut query: Query<(&mut TransformGizmo, &GlobalTransform)>,
-    mut gizmo_events: EventWriter<TransformGizmoEvent>,
+    mut gizmo_events: MessageWriter<TransformGizmoEvent>,
     mut commands: Commands,
     initial_transform_query: Query<Entity, With<InitialTransform>>,
 ) {

--- a/crates/bevy_transform_gizmos/src/lib.rs
+++ b/crates/bevy_transform_gizmos/src/lib.rs
@@ -11,8 +11,9 @@
 //! Then, when these entities are selected via [`bevy_editor_core::selection`] the
 //! transform gizmo will appear and allow you to move and rotate your selection.
 
+use bevy::camera::Projection;
 use bevy::picking::{backend::ray::RayMap, pointer::PointerId};
-use bevy::{prelude::*, render::camera::Projection, transform::TransformSystems};
+use bevy::{prelude::*, transform::TransformSystems};
 use bevy_editor_core::selection::EditorSelection;
 use mesh::{RotationGizmo, ViewTranslateGizmo};
 
@@ -44,7 +45,7 @@ pub enum TransformGizmoSystems {
 }
 
 /// Event thats sent when a [`TransformGizmoInteraction`] finishes.
-#[derive(Debug, Clone, Event, BufferedEvent)]
+#[derive(Debug, Clone, Event, Message)]
 pub struct TransformGizmoEvent {
     /// The starting position of the gizmo before the interaction.
     pub from: GlobalTransform,

--- a/crates/bevy_transform_gizmos/src/mesh.rs
+++ b/crates/bevy_transform_gizmos/src/mesh.rs
@@ -2,8 +2,9 @@ use std::f32::consts::TAU;
 
 use crate::{InteractionKind, InternalGizmoCamera, ScaleGizmo, TransformGizmo, TranslationGizmo};
 use bevy::{
-    core_pipeline::core_3d::Camera3dDepthLoadOp, pbr::NotShadowCaster, prelude::*,
-    render::view::RenderLayers,
+    camera::{Camera3dDepthLoadOp, visibility::RenderLayers},
+    light::NotShadowCaster,
+    prelude::*,
 };
 
 #[derive(Component)]

--- a/crates/bevy_transform_gizmos/src/normalization.rs
+++ b/crates/bevy_transform_gizmos/src/normalization.rs
@@ -1,6 +1,6 @@
 //! Normalization module. See [`Normalize3d`].
 
-use bevy::{prelude::*, render::camera::Camera, transform::TransformSystems};
+use bevy::{camera::Camera, prelude::*, transform::TransformSystems};
 
 use crate::{GizmoCamera, TransformGizmoSettings, TransformGizmoSystems};
 

--- a/crates/bevy_undo/examples/cube_move.rs
+++ b/crates/bevy_undo/examples/cube_move.rs
@@ -104,7 +104,7 @@ fn move_cube(
     }
 }
 
-fn send_undo_event(mut events: EventWriter<UndoRedo>, inputs: Res<ButtonInput<KeyCode>>) {
+fn send_undo_event(mut events: MessageWriter<UndoRedo>, inputs: Res<ButtonInput<KeyCode>>) {
     if inputs.just_pressed(KeyCode::KeyZ)
         && inputs.pressed(KeyCode::ControlLeft)
         && !inputs.pressed(KeyCode::ShiftLeft)

--- a/crates/bevy_undo/src/lib.rs
+++ b/crates/bevy_undo/src/lib.rs
@@ -153,8 +153,8 @@ impl Plugin for UndoPlugin {
         app.init_resource::<UndoIgnoreStorage>();
         app.init_resource::<ChangeChainSettings>();
 
-        app.add_event::<NewChange>();
-        app.add_event::<UndoRedo>();
+        app.add_message::<NewChange>();
+        app.add_message::<UndoRedo>();
 
         app.configure_sets(
             PostUpdate,
@@ -353,7 +353,7 @@ fn clear_one_frame_ignore(
 }
 
 fn undo_redo_logic(world: &mut World) {
-    world.resource_scope::<Events<UndoRedo>, _>(|world, mut events| {
+    world.resource_scope::<Messages<UndoRedo>, _>(|world, mut events| {
         world.resource_scope::<ChangeChain, _>(|world, mut change_chain| {
             {
                 let mut reader = events.get_cursor();
@@ -1152,7 +1152,7 @@ impl AppAutoUndo for App {
 
         self.world_mut()
             .insert_resource(AutoUndoStorage::<T>::default());
-        self.add_event::<UndoRedoApplied<T>>();
+        self.add_message::<UndoRedoApplied<T>>();
 
         self.add_systems(
             PostUpdate,
@@ -1178,7 +1178,7 @@ impl AppAutoUndo for App {
 
         self.world_mut()
             .insert_resource(AutoUndoStorage::<T>::default());
-        self.add_event::<UndoRedoApplied<T>>();
+        self.add_message::<UndoRedoApplied<T>>();
 
         self.add_systems(
             PostUpdate,

--- a/crates/bevy_undo/src/lib.rs
+++ b/crates/bevy_undo/src/lib.rs
@@ -247,7 +247,7 @@ pub enum UndoSet {
 ///     }
 /// }
 /// ```
-#[derive(Event, BufferedEvent)]
+#[derive(Event, Message)]
 pub struct UndoRedoApplied<T> {
     /// The entity that was modified.
     pub entity: Entity,
@@ -485,7 +485,7 @@ pub enum ChangeResult {
     SuccessWithRemap(Vec<(Entity, Entity)>),
 }
 /// Represents an undo or redo operation to be performed on the change chain.
-#[derive(Event, BufferedEvent)]
+#[derive(Event, Message)]
 pub enum UndoRedo {
     /// Requests to undo the last change in the change chain.
     Undo,
@@ -495,7 +495,7 @@ pub enum UndoRedo {
 }
 
 /// Represents a new change to be added to the change chain.
-#[derive(Event, BufferedEvent, Clone)]
+#[derive(Event, Message, Clone)]
 pub struct NewChange {
     /// The change to be added to the change chain, wrapped in an Arc for shared ownership.
     pub change: Arc<dyn EditorChange + Send + Sync>,
@@ -682,7 +682,7 @@ impl<T: Component + Reflect + FromReflect> EditorChange for ReflectedComponentCh
             .entity_mut(e)
             .insert(<T as FromReflect>::from_reflect(&self.old_value).unwrap())
             .insert(OneFrameUndoIgnore::default());
-        world.write_event(UndoRedoApplied::<T> {
+        world.write_message(UndoRedoApplied::<T> {
             entity: e,
             _phantom: std::marker::PhantomData,
         });
@@ -794,7 +794,7 @@ impl<T: Component + Reflect + FromReflect> EditorChange for ReflectedAddedCompon
             .resource_mut::<UndoIgnoreStorage>()
             .storage
             .insert(dst, OneFrameUndoIgnore::default());
-        world.write_event(UndoRedoApplied::<T> {
+        world.write_message(UndoRedoApplied::<T> {
             entity: dst,
             _phantom: std::marker::PhantomData,
         });
@@ -915,7 +915,7 @@ impl<T: Component + Reflect + FromReflect> EditorChange for ReflectedRemovedComp
             .entity_mut(dst)
             .insert(<T as FromReflect>::from_reflect(&self.old_value).unwrap())
             .insert(OneFrameUndoIgnore::default());
-        world.write_event(UndoRedoApplied::<T> {
+        world.write_message(UndoRedoApplied::<T> {
             entity: dst,
             _phantom: std::marker::PhantomData,
         });
@@ -1532,7 +1532,7 @@ mod tests {
         app.update();
 
         let test_id = app.world_mut().spawn_empty().id();
-        app.world_mut().write_event(NewChange {
+        app.world_mut().write_message(NewChange {
             change: Arc::new(AddedEntity { entity: test_id }),
         });
 
@@ -1557,7 +1557,7 @@ mod tests {
 
         assert!(app.world_mut().get_entity(test_id).is_ok());
 
-        app.world_mut().write_event(UndoRedo::Undo);
+        app.world_mut().write_message(UndoRedo::Undo);
 
         app.update();
         app.update();
@@ -1569,7 +1569,7 @@ mod tests {
         assert!(app.world_mut().get::<Name>(test_id).is_none());
         assert!(app.world_mut().get_entity(test_id).is_ok());
 
-        app.world_mut().write_event(UndoRedo::Undo);
+        app.world_mut().write_message(UndoRedo::Undo);
         app.update();
         app.update();
 
@@ -1586,10 +1586,10 @@ mod tests {
         let test_id_1 = app.world_mut().spawn(UndoMarker).id();
         let test_id_2 = app.world_mut().spawn(UndoMarker).id();
 
-        app.world_mut().write_event(NewChange {
+        app.world_mut().write_message(NewChange {
             change: Arc::new(AddedEntity { entity: test_id_1 }),
         });
-        app.world_mut().write_event(NewChange {
+        app.world_mut().write_message(NewChange {
             change: Arc::new(AddedEntity { entity: test_id_2 }),
         });
 
@@ -1603,14 +1603,14 @@ mod tests {
         app.cleanup();
 
         app.world_mut().entity_mut(test_id_1).despawn();
-        app.world_mut().write_event(NewChange {
+        app.world_mut().write_message(NewChange {
             change: Arc::new(RemovedEntity { entity: test_id_1 }),
         });
 
         app.update();
         app.update();
 
-        app.world_mut().write_event(UndoRedo::Undo);
+        app.world_mut().write_message(UndoRedo::Undo);
 
         app.update();
         app.update();

--- a/crates/bevy_undo/src/lib.rs
+++ b/crates/bevy_undo/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! fn handle_input(
 //!     keys: Res<ButtonInput<KeyCode>>,
-//!     mut undo_redo: EventWriter<UndoRedo>,
+//!     mut undo_redo: MessageWriter<UndoRedo>,
 //! ) {
 //!     if keys.just_pressed(KeyCode::KeyZ) {
 //!         undo_redo.write(UndoRedo::Undo);
@@ -51,7 +51,7 @@
 //!
 //! fn apply_transform(
 //!     mut query: Query<(Entity, &mut Transform), With<UndoMarker>>,
-//!     mut new_changes: EventWriter<NewChange>,
+//!     mut new_changes: MessageWriter<NewChange>,
 //! ) {
 //!     for (entity, mut transform) in query.iter_mut() {
 //!         // Apply some change
@@ -240,7 +240,7 @@ pub enum UndoSet {
 /// ```rust
 /// use bevy::prelude::*;
 /// use bevy_undo::*;
-/// fn react_to_transform_undo_redo(mut events: EventReader<UndoRedoApplied<Transform>>) {
+/// fn react_to_transform_undo_redo(mut events: MessageReader<UndoRedoApplied<Transform>>) {
 ///     for event in events.read() {
 ///         println!("Transform of entity {:?} was modified by undo/redo", event.entity);
 ///         // Perform any necessary updates or side effects
@@ -295,7 +295,7 @@ fn update_change_chain(
     mut buffer: Local<Vec<NewChange>>, //Buffer will use for chain reaction changes and collecting them together
     settings: Res<ChangeChainSettings>,
     mut change_chain: ResMut<ChangeChain>,
-    mut events: EventReader<NewChange>,
+    mut events: MessageReader<NewChange>,
 ) {
     //collect buffer
     let mut events_on_current_frame = 0;
@@ -1294,7 +1294,7 @@ fn apply_for_every_typed_field<D: Reflect + TypePath>(
 }
 
 fn auto_remap_undo_redo<T: Component + Reflect>(
-    mut undoredo_applied: EventReader<UndoRedoApplied<T>>,
+    mut undoredo_applied: MessageReader<UndoRedoApplied<T>>,
     mut commands: Commands,
 ) {
     for event in undoredo_applied.read() {
@@ -1349,7 +1349,7 @@ fn auto_undo_add_init<T: Component + Clone>(
     mut storage: ResMut<AutoUndoStorage<T>>,
     query: Query<(Entity, &T), (With<UndoMarker>, Added<T>, Without<OneFrameUndoIgnore>)>,
     just_maker_added_query: Query<(Entity, &T), (Added<UndoMarker>, Without<OneFrameUndoIgnore>)>,
-    mut new_changes: EventWriter<NewChange>,
+    mut new_changes: MessageWriter<NewChange>,
 ) {
     for (e, data) in query.iter() {
         storage.storage.insert(e, data.clone());
@@ -1370,7 +1370,7 @@ fn auto_undo_reflected_add_init<T: Component + Reflect + FromReflect>(
     mut storage: ResMut<AutoUndoStorage<T>>,
     query: Query<(Entity, &T), (With<UndoMarker>, Added<T>, Without<OneFrameUndoIgnore>)>,
     just_maker_added_query: Query<(Entity, &T), (Added<UndoMarker>, Without<OneFrameUndoIgnore>)>,
-    mut new_changes: EventWriter<NewChange>,
+    mut new_changes: MessageWriter<NewChange>,
 ) {
     for (e, data) in query.iter() {
         storage
@@ -1403,7 +1403,7 @@ fn auto_undo_remove_detect<T: Component + Clone>(
     _commands: Commands,
     mut storage: ResMut<AutoUndoStorage<T>>,
     mut removed_query: RemovedComponents<T>,
-    mut new_changes: EventWriter<NewChange>,
+    mut new_changes: MessageWriter<NewChange>,
     ignore_storage: ResMut<UndoIgnoreStorage>,
 ) {
     for e in removed_query.read() {
@@ -1424,7 +1424,7 @@ fn auto_undo_reflected_remove_detect<T: Component + Reflect + FromReflect>(
     _commands: Commands,
     mut storage: ResMut<AutoUndoStorage<T>>,
     mut removed_query: RemovedComponents<T>,
-    mut new_changes: EventWriter<NewChange>,
+    mut new_changes: MessageWriter<NewChange>,
     ignore_storage: ResMut<UndoIgnoreStorage>,
 ) {
     for e in removed_query.read() {
@@ -1456,7 +1456,7 @@ fn auto_undo_system<T: Component + Clone>(
     mut commands: Commands,
     mut storage: ResMut<AutoUndoStorage<T>>,
     mut query: Query<(Entity, Ref<T>), With<ChangedMarker<T>>>,
-    mut new_change: EventWriter<NewChange>,
+    mut new_change: MessageWriter<NewChange>,
 ) {
     for (e, data) in query.iter_mut() {
         if !data.is_changed() {
@@ -1482,7 +1482,7 @@ fn auto_undo_reflected_system<T: Component + Reflect + FromReflect>(
     mut commands: Commands,
     mut storage: ResMut<AutoUndoStorage<T>>,
     mut query: Query<(Entity, Ref<T>, &mut ChangedMarker<T>)>,
-    mut new_change: EventWriter<NewChange>,
+    mut new_change: MessageWriter<NewChange>,
 ) {
     for (e, data, mut marker) in query.iter_mut() {
         if !data.is_changed() {

--- a/templates/getting_started/src/main.rs
+++ b/templates/getting_started/src/main.rs
@@ -208,7 +208,7 @@ fn move_player(
     mut transforms: Query<&mut Transform>,
     time: Res<Time>,
 ) {
-    if game.player.move_cooldown.tick(time.delta()).finished() {
+    if game.player.move_cooldown.tick(time.delta()).is_finished() {
         let mut moved = false;
         let mut rotation = 0.0;
 
@@ -320,7 +320,7 @@ fn spawn_bonus(
     mut rng: ResMut<Random>,
 ) {
     // make sure we wait enough time before spawning the next cake
-    if !timer.0.tick(time.delta()).finished() {
+    if !timer.0.tick(time.delta()).is_finished() {
         return;
     }
 


### PR DESCRIPTION
Overview of this PR:

1. Update API (points Bevy to the latest version: https://github.com/cart/bevy/tree/next-gen-scenes-0.17.1).

2. Rollback changes to address some modules that were deprecated upstream.